### PR TITLE
[fix] : today_order가 모두 0으로 할당되는 문제를 해결한다

### DIFF
--- a/src/main/java/server/poptato/global/config/AsyncConfig.java
+++ b/src/main/java/server/poptato/global/config/AsyncConfig.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 @EnableAsync
-public class AsyncConfig{
+public class AsyncConfig {
 
     @Bean(name = "taskExecutor")
     public Executor getAsyncExecutor() {

--- a/src/main/java/server/poptato/todo/application/TodoScheduler.java
+++ b/src/main/java/server/poptato/todo/application/TodoScheduler.java
@@ -1,6 +1,7 @@
 package server.poptato.todo.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +14,7 @@ public class TodoScheduler {
     /**
      * 매일 새벽 특정 시간에 할 일 상태를 업데이트한다.
      */
+    @Async
     @Scheduled(cron = "${scheduling.todoCron}")
     public void updateTodoType() {
         todoBatchService.updateTodayTodosAndSave();

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -610,7 +610,7 @@ public class TodoService {
             int todayOrder = todoRepository.findMaxTodayOrderByUserIdOrZero(userId);
 
             // 1. 마감 기한이 오늘인 BACKLOG -> TODAY
-            List<Todo> deadlineMatchedTodos = todoRepository.findTodosDueToday(userId, today, TodayStatus.INCOMPLETE);
+            List<Todo> deadlineMatchedTodos = todoRepository.findTodosByDeadLine(userId, today);
 
             for (Todo todo : deadlineMatchedTodos) {
                 todo.changeToToday(todayOrder++);

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -42,7 +42,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-@Transactional
 @RequiredArgsConstructor
 @Service
 public class TodoService {
@@ -64,6 +63,8 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param todoId 삭제할 할 일 ID
      */
+
+    @Transactional
     public void deleteTodoById(Long userId, Long todoId) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -92,6 +93,7 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param todoId 대상 할 일 ID
      */
+    @Transactional
     public void toggleIsBookmark(Long userId, Long todoId) {
         Todo todo = validateAndReturnTodo(userId, todoId);
         todo.toggleBookmark();
@@ -103,6 +105,7 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param swipeRequestDto 스와이프 요청 데이터
      */
+    @Transactional
     public void swipe(Long userId, SwipeRequestDto swipeRequestDto) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, swipeRequestDto.todoId());
@@ -142,6 +145,7 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param requestDto 순서 변경 요청 데이터
      */
+    @Transactional
     public void dragAndDrop(Long userId, TodoDragAndDropRequestDto requestDto) {
         userValidator.checkIsExistUser(userId);
 
@@ -205,6 +209,7 @@ public class TodoService {
      * @param todoId 조회할 할 일 ID
      * @return 할 일 상세 정보
      */
+    @Transactional(readOnly = true)
     public TodoDetailResponseDto getTodoInfo(Long userId, MobileType mobileType, Long todoId) {
         userValidator.checkIsExistUser(userId);
         String imageUrlExtension = mobileType.getImageUrlExtension();
@@ -229,6 +234,7 @@ public class TodoService {
      * @param todoId 업데이트할 할 일 ID
      * @param requestDto 시간 업데이트 요청 데이터
      */
+    @Transactional
     public void updateTime(Long userId, Long todoId, TimeUpdateRequestDto requestDto) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -256,6 +262,7 @@ public class TodoService {
      * @param todoId 업데이트할 할 일 ID
      * @param requestDto 마감 기한 업데이트 요청 데이터
      */
+    @Transactional
     public void updateDeadline(Long userId, Long todoId, DeadlineUpdateRequestDto requestDto) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -269,6 +276,7 @@ public class TodoService {
      * @param todoId 루틴을 등록할 할 일 ID
      * @param requestDto 루틴 등록 요일
      */
+    @Transactional
     public void createRoutine(Long userId, Long todoId, RoutineUpdateRequestDto requestDto) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -294,6 +302,7 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param todoId 루틴을 삭제할 할 일 ID
      */
+    @Transactional
     public void deleteRoutine(Long userId, Long todoId) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -308,6 +317,7 @@ public class TodoService {
      * @param todoId 업데이트할 할 일 ID
      * @param requestDto 내용 업데이트 요청 데이터
      */
+    @Transactional
     public void updateContent(Long userId, Long todoId, ContentUpdateRequestDto requestDto) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -320,35 +330,11 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param todoId 업데이트할 할 일 ID
      */
+    @Transactional
     public void updateIsCompleted(Long userId, Long todoId) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
         updateTodayIsCompleted(findTodo);
-    }
-
-    /**
-     * 특정 할 일의 어제 완료 상태를 업데이트합니다.
-     * - 미완료(INCOMPLETE) 상태 → 완료(COMPLETED) 상태로 변경
-     * - 완료 시간을 "어제 날짜의 23:59"로 설정
-     * - 반복 할 일이면 새로운 백로그 할 일을 생성
-     *
-     * @param findTodo 업데이트할 할 일 객체
-     */
-    private void updateYesterdayIsCompleted(Todo findTodo) {
-        int existBacklogOrder = findTodo.getBacklogOrder();
-        findTodo.updateYesterdayToCompleted();
-        // 완료 시간을 "어제 날짜의 23:59"로 설정
-        LocalDateTime yesterday = LocalDate.now().minusDays(1).atTime(23, 59);
-        CompletedDateTime completedDateTime = CompletedDateTime.builder()
-                .todoId(findTodo.getId())
-                .dateTime(yesterday)
-                .build();
-        completedDateTimeRepository.save(completedDateTime);
-
-        // 반복 할 일이라면, 오늘 날짜로 지정하여 백로그에 추가
-        if (findTodo.isRepeat() || findTodo.isRoutine()) {
-            findTodo.changeToBacklog(existBacklogOrder);
-        }
     }
 
     /**
@@ -393,6 +379,7 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param request 체크된 할 일 목록 DTO
      */
+    @Transactional
     public void checkYesterdayTodos(Long userId, CheckYesterdayTodosRequestDto request) {
         userValidator.checkIsExistUser(userId);
         List<Todo> allYesterdays = todoRepository.findIncompleteYesterdays(userId);
@@ -422,6 +409,31 @@ public class TodoService {
     }
 
     /**
+     * 특정 할 일의 어제 완료 상태를 업데이트합니다.
+     * - 미완료(INCOMPLETE) 상태 → 완료(COMPLETED) 상태로 변경
+     * - 완료 시간을 "어제 날짜의 23:59"로 설정
+     * - 반복 할 일이면 새로운 백로그 할 일을 생성
+     *
+     * @param findTodo 업데이트할 할 일 객체
+     */
+    private void updateYesterdayIsCompleted(Todo findTodo) {
+        int existBacklogOrder = findTodo.getBacklogOrder();
+        findTodo.updateYesterdayToCompleted();
+        // 완료 시간을 "어제 날짜의 23:59"로 설정
+        LocalDateTime yesterday = LocalDate.now().minusDays(1).atTime(23, 59);
+        CompletedDateTime completedDateTime = CompletedDateTime.builder()
+                .todoId(findTodo.getId())
+                .dateTime(yesterday)
+                .build();
+        completedDateTimeRepository.save(completedDateTime);
+
+        // 반복 할 일이라면, 오늘 날짜로 지정하여 백로그에 추가
+        if (findTodo.isRepeat() || findTodo.isRoutine()) {
+            findTodo.changeToBacklog(existBacklogOrder);
+        }
+    }
+
+    /**
      * 히스토리 데이터를 조회합니다.
      *
      * @param userId 사용자 ID
@@ -430,6 +442,7 @@ public class TodoService {
      * @param size 페이지 크기
      * @return 히스토리 데이터
      */
+    @Transactional(readOnly = true)
     public PaginatedHistoryResponseDto getHistories(Long userId, LocalDate localDate, int page, int size) {
         userValidator.checkIsExistUser(userId);
         if (localDate.isBefore(LocalDate.now())) {
@@ -478,6 +491,7 @@ public class TodoService {
      * @param month 조회할 월
      * @return 할 일이 존재하는 날짜 리스트
      */
+    @Transactional(readOnly = true)
     public List<LocalDate> getLegacyHistoriesCalendar(Long userId, String year, int month) {
         return completedDateTimeRepository.findHistoryExistingDates(userId, year, month).stream()
                 .map(LocalDateTime::toLocalDate)
@@ -498,6 +512,7 @@ public class TodoService {
      * @param month 조회할 월 (1~12)
      * @return 날짜별 히스토리/백로그 정보 DTO
      */
+    @Transactional(readOnly = true)
     public HistoryCalendarListResponseDto getHistoriesCalendar(Long userId, String year, int month) {
         Map<LocalDate, Integer> historyCountByDate =
                 completedDateTimeRepository.findHistoryExistingDates(userId, year, month).stream()
@@ -526,6 +541,7 @@ public class TodoService {
      * @param todoId 업데이트할 할 일 ID
      * @param requestDto 카테고리 업데이트 요청 데이터
      */
+    @Transactional
     public void updateCategory(Long userId, Long todoId, TodoCategoryUpdateRequestDto requestDto) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -542,6 +558,7 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param todoId 업데이트할 할 일 ID
      */
+    @Transactional
     public void updateIsRepeat(Long userId, Long todoId) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -554,6 +571,7 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param todoId 일반 반복 설정할 할 일 ID
      */
+    @Transactional
     public void createIsRepeat(Long userId, Long todoId) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -568,6 +586,7 @@ public class TodoService {
      * @param userId 사용자 ID
      * @param todoId 일반 반복 설정을 삭제할 할 일 ID
      */
+    @Transactional
     public void deleteIsRepeat(Long userId, Long todoId) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
@@ -585,14 +604,24 @@ public class TodoService {
      */
     @Transactional
     public void processUpdateDeadlineTodos(LocalDate today, List<Long> userIds) {
-        int basicTodayOrder = 0;
-        // 1. 마감 기한이 오늘인 할 일들 -> TODAY
-        todoRepository.updateBacklogTodosToToday(today, userIds, basicTodayOrder);
-        // 2. 오늘 요일이 포함된 요일 반복 설정된 할 일들 -> TODAY
         String todayDay = today.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.KOREAN);
-        todoRepository.updateBacklogTodosToTodayByRoutine(today, todayDay, userIds, basicTodayOrder);
 
-        entityManager.flush();
-        entityManager.clear();
+        for (Long userId : userIds) {
+            int todayOrder = todoRepository.findMaxTodayOrderByUserIdOrZero(userId);
+
+            // 1. 마감 기한이 오늘인 BACKLOG -> TODAY
+            List<Todo> deadlineMatchedTodos = todoRepository.findTodosDueToday(userId, today, TodayStatus.INCOMPLETE);
+
+            for (Todo todo : deadlineMatchedTodos) {
+                todo.changeToToday(todayOrder++);
+            }
+
+            // 2. 오늘 요일이 포함된 요일 반복 설정된 BACKLOG -> TODAY
+            List<Todo> routineMatchedTodos = todoRepository.findRoutineTodosByDay(userId, todayDay);
+
+            for (Todo todo : routineMatchedTodos) {
+                todo.changeToToday(todayOrder++);
+            }
+        }
     }
 }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -85,15 +85,8 @@ public interface TodoRepository {
                                  @Param("todayStatus") TodayStatus todayStatus
     );
 
-    void updateBacklogTodosToToday(@Param("today") LocalDate today,
-                                   @Param("userIds") List<Long> userIds,
-                                   @Param("basicTodayOrder") Integer basicTodayOrder
-    );
-
-    void updateBacklogTodosToTodayByRoutine(@Param("today") LocalDate today,
-                                            @Param("todayDay") String todayDay,
-                                            @Param("userIds") List<Long> userIds,
-                                            @Param("basicTodayOrder") Integer basicTodayOrder
+    List<Todo> findRoutineTodosByDay(@Param("userId") Long userId,
+                                     @Param("todayDay") String todayDay
     );
 
     List<Todo> findIncompleteYesterdays(Long userId);

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -85,6 +85,10 @@ public interface TodoRepository {
                                  @Param("todayStatus") TodayStatus todayStatus
     );
 
+    List<Todo> findTodosByDeadLine(@Param("userId") Long userId,
+                                   @Param("deadline") LocalDate deadline
+    );
+
     List<Todo> findRoutineTodosByDay(@Param("userId") Long userId,
                                      @Param("todayDay") String todayDay
     );

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -186,6 +186,15 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
                                  @Param("todayStatus") TodayStatus todayStatus
     );
 
+    @Query("""
+    SELECT t FROM Todo t
+    WHERE t.type = 'BACKLOG'
+        AND t.userId = :userId
+        AND t.deadline = :deadline
+    """)
+    List<Todo> findTodosByDeadLine(@Param("userId") Long userId,
+                                 @Param("deadline") LocalDate deadline);
+
     @Query(value = """
     SELECT t.* FROM todo t
     JOIN routine r ON t.id = r.todo_id

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.poptato.todo.domain.entity.Todo;
@@ -187,43 +186,15 @@ public interface JpaTodoRepository extends TodoRepository, JpaRepository<Todo, L
                                  @Param("todayStatus") TodayStatus todayStatus
     );
 
-    @Modifying(clearAutomatically = true)
-    @Query("""
-        UPDATE Todo t
-        SET t.type = 'TODAY',
-            t.todayOrder = :basicTodayOrder,
-            t.todayStatus = 'INCOMPLETE',
-            t.todayDate = :today,
-            t.backlogOrder = NULL
-        WHERE t.type = 'BACKLOG'
-          AND t.deadline = :today
-          AND t.userId IN :userIds
-        """)
-    void updateBacklogTodosToToday(
-            @Param("today") LocalDate today,
-            @Param("userIds") List<Long> userIds,
-            @Param("basicTodayOrder") Integer basicTodayOrder
-    );
-
-    @Modifying
     @Query(value = """
-    UPDATE todo t
+    SELECT t.* FROM todo t
     JOIN routine r ON t.id = r.todo_id
-    SET t.type = 'TODAY',
-        t.today_order = :basicTodayOrder,
-        t.today_status = 'INCOMPLETE',
-        t.today_date = :today,
-        t.backlog_order = NULL
     WHERE t.type = 'BACKLOG'
       AND r.day = :todayDay
-      AND t.user_id IN (:userIds)
+      AND t.user_id = :userId
     """, nativeQuery = true)
-    void updateBacklogTodosToTodayByRoutine(
-            @Param("today") LocalDate today,
-            @Param("todayDay") String todayDay,
-            @Param("userIds") List<Long> userIds,
-            @Param("basicTodayOrder") Integer basicTodayOrder
-    );
+    List<Todo> findRoutineTodosByDay(@Param("userId") Long userId,
+                                     @Param("todayDay") String todayDay);
 
     @Query("""
         SELECT t


### PR DESCRIPTION
## ✅ PR 유형
> 어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 🚀 작업 내용
> 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

### 🚨 문제 
- 기존에는 자정에 `BACKLOG -> TODAY` 로 옮기는 과정에서 `today_order`가 모두 0으로 할당되었습니다. 
- 때문에 이 둘을 드래그앤드롭으로 위치를 변경하려고 하면 오류가 발생했습니다.

### ✅ 해결
- 쿼리에서 UPDATE 하는 것이 아니라, 유저 별로 BACKLOG를 가져온 후에 `today_order`를 순차적으로 할당하여 저장하는 식으로 변경하여 해결하였습니다.
- 다만 이는 기존 방식보다 성능은 좋지 않을 듯하여, 추후 유저가 늘어남에 따라 성능 측정을 해 보고 개선하면 좋을 것 같습니다.

### 🔀 비동기 처리
- 투두 스케줄러를 비동기로 처리하게 하여, 메인 스레드에 영향을 주지 않도록 하였습니다.
- 하지만 클래스 단에 `@Transactional`이 붙어있다면 비동기로 처리하는 경우에 트랜잭션이 제대로 수행되지 않을 수 있다는 문제가 있었습니다.
- 이를 위해서 `TodoService` 클래스 단에 붙어 있던 `@Transactional`을 서비스 별로 분리하였습니다.

---

## 📝️ 관련 이슈
> 본인이 작업한 내용이 어떤 Issue와 관련이 있는지 작성해주세요.

- Resolves : #114 

---

## 💬 기타 사항 or 추가 코멘트
> 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

- 추후 비동기 처리와 트랜잭션에 더 학습해 보아야 할 것 같습니다!
