### PR TITLE
[ILLDAN-202] refactor: User, Todo, Category, Note 도메인에 soft delete를 적용한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ out/
 .claude
 CLAUDE.md
 /docs
+.worktrees
 
 ##open-api (auto-generated)
 src/main/resources/static/docs/*

--- a/src/main/java/server/poptato/category/application/CategoryService.java
+++ b/src/main/java/server/poptato/category/application/CategoryService.java
@@ -122,8 +122,8 @@ public class CategoryService {
      */
     public void deleteCategory(Long userId, Long categoryId) {
         userValidator.checkIsExistUser(userId);
-        Category category = categoryValidator.validateAndReturnCategory(userId, categoryId);
-        category.softDelete();
+        categoryValidator.validateAndReturnCategory(userId, categoryId);
+        categoryRepository.softDeleteById(categoryId);
         todoRepository.softDeleteByCategoryId(categoryId);
     }
 

--- a/src/main/java/server/poptato/category/application/CategoryService.java
+++ b/src/main/java/server/poptato/category/application/CategoryService.java
@@ -115,7 +115,7 @@ public class CategoryService {
     }
 
     /**
-     * 특정 카테고리를 삭제합니다.
+     * 특정 카테고리를 삭제합니다 (Soft Delete).
      *
      * @param userId 사용자 ID
      * @param categoryId 삭제할 카테고리 ID
@@ -123,8 +123,8 @@ public class CategoryService {
     public void deleteCategory(Long userId, Long categoryId) {
         userValidator.checkIsExistUser(userId);
         Category category = categoryValidator.validateAndReturnCategory(userId, categoryId);
-        categoryRepository.delete(category);
-        todoRepository.deleteAllByCategoryId(categoryId);
+        category.softDelete();
+        todoRepository.softDeleteByCategoryId(categoryId);
     }
 
     /**

--- a/src/main/java/server/poptato/category/domain/entity/Category.java
+++ b/src/main/java/server/poptato/category/domain/entity/Category.java
@@ -1,6 +1,16 @@
 package server.poptato.category.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,9 +65,6 @@ public class Category extends BaseEntity {
         this.categoryOrder = categoryOrder;
     }
 
-    /**
-     * Soft Delete 처리
-     */
     public void softDelete() {
         this.isDeleted = true;
     }

--- a/src/main/java/server/poptato/category/domain/entity/Category.java
+++ b/src/main/java/server/poptato/category/domain/entity/Category.java
@@ -1,5 +1,7 @@
 package server.poptato.category.domain.entity;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -23,6 +25,7 @@ import server.poptato.global.dao.BaseEntity;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "category")
+@SQLRestriction("is_deleted = false")
 public class Category extends BaseEntity {
 
     @Id

--- a/src/main/java/server/poptato/category/domain/entity/Category.java
+++ b/src/main/java/server/poptato/category/domain/entity/Category.java
@@ -67,8 +67,4 @@ public class Category extends BaseEntity {
     public void updateCategoryOrder(int categoryOrder) {
         this.categoryOrder = categoryOrder;
     }
-
-    public void softDelete() {
-        this.isDeleted = true;
-    }
 }

--- a/src/main/java/server/poptato/category/domain/entity/Category.java
+++ b/src/main/java/server/poptato/category/domain/entity/Category.java
@@ -31,6 +31,9 @@ public class Category extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "emoji_id", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Emoji emoji;
@@ -50,5 +53,12 @@ public class Category extends BaseEntity {
 
     public void updateCategoryOrder(int categoryOrder) {
         this.categoryOrder = categoryOrder;
+    }
+
+    /**
+     * Soft Delete 처리
+     */
+    public void softDelete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/server/poptato/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/server/poptato/category/domain/repository/CategoryRepository.java
@@ -20,6 +20,8 @@ public interface CategoryRepository {
 
     void deleteByUserId(Long userId);
 
+    void softDeleteByUserId(Long userId);
+
     default Page<Category> findCategories(Long userId, Pageable pageable) {
         return findDefaultAndByUserIdOrderByCategoryOrder(userId, pageable);
     }

--- a/src/main/java/server/poptato/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/server/poptato/category/domain/repository/CategoryRepository.java
@@ -16,10 +16,6 @@ public interface CategoryRepository {
 
     Optional<Category> findById(Long categoryId);
 
-    void delete(Category category);
-
-    void deleteByUserId(Long userId);
-
     void softDeleteByUserId(Long userId);
 
     default Page<Category> findCategories(Long userId, Pageable pageable) {

--- a/src/main/java/server/poptato/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/server/poptato/category/domain/repository/CategoryRepository.java
@@ -16,6 +16,8 @@ public interface CategoryRepository {
 
     Optional<Category> findById(Long categoryId);
 
+    void softDeleteById(Long categoryId);
+
     void softDeleteByUserId(Long userId);
 
     default Page<Category> findCategories(Long userId, Pageable pageable) {

--- a/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
+++ b/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
@@ -35,7 +35,7 @@ public interface JpaCategoryRepository extends CategoryRepository, JpaRepository
         """)
     Optional<Category> findById(@Param("id") Long id);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE Category c
         SET c.isDeleted = true

--- a/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
+++ b/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
@@ -16,16 +16,14 @@ public interface JpaCategoryRepository extends CategoryRepository, JpaRepository
     @Query("""
         SELECT MAX(c.categoryOrder)
         FROM Category c
-        WHERE (c.userId = :userId OR c.userId = -1)
-          AND c.isDeleted = false
+        WHERE c.userId = :userId OR c.userId = -1
         """)
     Optional<Integer> findMaxCategoryOrderByUserId(@Param("userId") Long userId);
 
     @Query("""
         SELECT c
         FROM Category c
-        WHERE (c.userId = :userId OR c.userId = -1)
-          AND c.isDeleted = false
+        WHERE c.userId = :userId OR c.userId = -1
         ORDER BY c.categoryOrder ASC
         """)
     Page<Category> findDefaultAndByUserIdOrderByCategoryOrder(@Param("userId") Long userId, Pageable pageable);
@@ -34,7 +32,6 @@ public interface JpaCategoryRepository extends CategoryRepository, JpaRepository
         SELECT c
         FROM Category c
         WHERE c.id = :id
-          AND c.isDeleted = false
         """)
     Optional<Category> findById(@Param("id") Long id);
 

--- a/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
+++ b/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
@@ -27,13 +27,16 @@ public interface JpaCategoryRepository extends CategoryRepository, JpaRepository
         ORDER BY c.categoryOrder ASC
         """)
     Page<Category> findDefaultAndByUserIdOrderByCategoryOrder(@Param("userId") Long userId, Pageable pageable);
+	
+	Optional<Category> findById(@Param("id") Long id);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
-        SELECT c
-        FROM Category c
-        WHERE c.id = :id
+        UPDATE Category c
+        SET c.isDeleted = true
+        WHERE c.id = :categoryId
         """)
-    Optional<Category> findById(@Param("id") Long id);
+    void softDeleteById(@Param("categoryId") Long categoryId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
+++ b/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
@@ -35,7 +35,7 @@ public interface JpaCategoryRepository extends CategoryRepository, JpaRepository
         """)
     Optional<Category> findById(@Param("id") Long id);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
         UPDATE Category c
         SET c.isDeleted = true

--- a/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
+++ b/src/main/java/server/poptato/category/infra/JpaCategoryRepository.java
@@ -3,6 +3,7 @@ package server.poptato.category.infra;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.poptato.category.domain.entity.Category;
@@ -15,15 +16,33 @@ public interface JpaCategoryRepository extends CategoryRepository, JpaRepository
     @Query("""
         SELECT MAX(c.categoryOrder)
         FROM Category c
-        WHERE c.userId = :userId OR c.userId = -1
-    """)
+        WHERE (c.userId = :userId OR c.userId = -1)
+          AND c.isDeleted = false
+        """)
     Optional<Integer> findMaxCategoryOrderByUserId(@Param("userId") Long userId);
 
     @Query("""
         SELECT c
         FROM Category c
-        WHERE c.userId = :userId OR c.userId = -1
+        WHERE (c.userId = :userId OR c.userId = -1)
+          AND c.isDeleted = false
         ORDER BY c.categoryOrder ASC
-    """)
+        """)
     Page<Category> findDefaultAndByUserIdOrderByCategoryOrder(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+        SELECT c
+        FROM Category c
+        WHERE c.id = :id
+          AND c.isDeleted = false
+        """)
+    Optional<Category> findById(@Param("id") Long id);
+
+    @Modifying
+    @Query("""
+        UPDATE Category c
+        SET c.isDeleted = true
+        WHERE c.userId = :userId
+        """)
+    void softDeleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/server/poptato/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/server/poptato/global/exception/GlobalExceptionHandler.java
@@ -173,9 +173,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     // 로그 기록 메서드
     private void logError(String message, Object errorDetails) {
-        // 예외 객체가 Throwable이면 stack trace 출력 없이 메시지만
         if (errorDetails instanceof Throwable t) {
-            log.error("{}: {}", message, t.getMessage());
+            log.error("{}: {}", message, t.getMessage(), t);  // 스택 트레이스 포함
         } else {
             log.error("{}: {}", message, errorDetails);
         }

--- a/src/main/java/server/poptato/note/application/NoteService.java
+++ b/src/main/java/server/poptato/note/application/NoteService.java
@@ -108,9 +108,9 @@ public class NoteService {
     @Transactional
     public void deleteNote(Long userId, Long noteId) {
         userValidator.checkIsExistUser(userId);
-        Note note = noteRepository.findByIdAndUserId(noteId, userId)
+        noteRepository.findByIdAndUserId(noteId, userId)
                 .orElseThrow(() -> new CustomException(NoteErrorStatus._NOT_FOUND_NOTE));
 
-        note.softDelete();
+        noteRepository.softDeleteById(noteId);
     }
 }

--- a/src/main/java/server/poptato/note/application/NoteService.java
+++ b/src/main/java/server/poptato/note/application/NoteService.java
@@ -100,7 +100,7 @@ public class NoteService {
     }
 
     /**
-     * 노트를 삭제합니다.
+     * 노트를 삭제합니다 (Soft Delete).
      * @param userId 사용자 ID
      * @param noteId 노트 ID
      * @throws CustomException 노트가 존재하지 않을 경우
@@ -111,6 +111,6 @@ public class NoteService {
         Note note = noteRepository.findByIdAndUserId(noteId, userId)
                 .orElseThrow(() -> new CustomException(NoteErrorStatus._NOT_FOUND_NOTE));
 
-        noteRepository.delete(note);
+        note.softDelete();
     }
 }

--- a/src/main/java/server/poptato/note/domain/entity/Note.java
+++ b/src/main/java/server/poptato/note/domain/entity/Note.java
@@ -27,6 +27,9 @@ public class Note extends BaseEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
     @Builder
     public Note(Long userId) {
         this.userId = userId;
@@ -35,5 +38,12 @@ public class Note extends BaseEntity {
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    /**
+     * Soft Delete 처리
+     */
+    public void softDelete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/server/poptato/note/domain/entity/Note.java
+++ b/src/main/java/server/poptato/note/domain/entity/Note.java
@@ -1,5 +1,7 @@
 package server.poptato.note.domain.entity;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -17,6 +19,7 @@ import server.poptato.global.dao.BaseEntity;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "note")
+@SQLRestriction("is_deleted = false")
 public class Note extends BaseEntity {
 
     @Id

--- a/src/main/java/server/poptato/note/domain/entity/Note.java
+++ b/src/main/java/server/poptato/note/domain/entity/Note.java
@@ -48,8 +48,4 @@ public class Note extends BaseEntity {
         this.title = title;
         this.content = content;
     }
-
-    public void softDelete() {
-        this.isDeleted = true;
-    }
 }

--- a/src/main/java/server/poptato/note/domain/entity/Note.java
+++ b/src/main/java/server/poptato/note/domain/entity/Note.java
@@ -1,6 +1,12 @@
 package server.poptato.note.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,9 +46,6 @@ public class Note extends BaseEntity {
         this.content = content;
     }
 
-    /**
-     * Soft Delete 처리
-     */
     public void softDelete() {
         this.isDeleted = true;
     }

--- a/src/main/java/server/poptato/note/domain/repository/NoteRepository.java
+++ b/src/main/java/server/poptato/note/domain/repository/NoteRepository.java
@@ -15,4 +15,6 @@ public interface NoteRepository {
     Optional<Note> findByIdAndUserId(Long noteId, Long userId);
 
     void delete(Note note);
+
+    void softDeleteByUserId(Long userId);
 }

--- a/src/main/java/server/poptato/note/domain/repository/NoteRepository.java
+++ b/src/main/java/server/poptato/note/domain/repository/NoteRepository.java
@@ -14,5 +14,7 @@ public interface NoteRepository {
 
     Optional<Note> findByIdAndUserId(Long noteId, Long userId);
 
+    void softDeleteById(Long noteId);
+
     void softDeleteByUserId(Long userId);
 }

--- a/src/main/java/server/poptato/note/domain/repository/NoteRepository.java
+++ b/src/main/java/server/poptato/note/domain/repository/NoteRepository.java
@@ -14,7 +14,5 @@ public interface NoteRepository {
 
     Optional<Note> findByIdAndUserId(Long noteId, Long userId);
 
-    void delete(Note note);
-
     void softDeleteByUserId(Long userId);
 }

--- a/src/main/java/server/poptato/note/infra/JpaNoteRepository.java
+++ b/src/main/java/server/poptato/note/infra/JpaNoteRepository.java
@@ -38,7 +38,7 @@ public interface JpaNoteRepository extends JpaRepository<Note, Long> {
         """)
     Optional<Note> findByIdAndUserId(@Param("noteId") Long noteId, @Param("userId") Long userId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE Note n
         SET n.isDeleted = true

--- a/src/main/java/server/poptato/note/infra/JpaNoteRepository.java
+++ b/src/main/java/server/poptato/note/infra/JpaNoteRepository.java
@@ -20,7 +20,7 @@ public interface JpaNoteRepository extends JpaRepository<Note, Long> {
             n.modify_date AS modifyDate
         FROM note n
         WHERE n.user_id = :userId
-          AND n.is_deleted = 0
+          AND n.is_deleted = false
         ORDER BY n.modify_date DESC
         """,
             nativeQuery = true)
@@ -35,7 +35,6 @@ public interface JpaNoteRepository extends JpaRepository<Note, Long> {
         FROM Note n
         WHERE n.id = :noteId
           AND n.userId = :userId
-          AND n.isDeleted = false
         """)
     Optional<Note> findByIdAndUserId(@Param("noteId") Long noteId, @Param("userId") Long userId);
 

--- a/src/main/java/server/poptato/note/infra/JpaNoteRepository.java
+++ b/src/main/java/server/poptato/note/infra/JpaNoteRepository.java
@@ -38,7 +38,7 @@ public interface JpaNoteRepository extends JpaRepository<Note, Long> {
         """)
     Optional<Note> findByIdAndUserId(@Param("noteId") Long noteId, @Param("userId") Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
         UPDATE Note n
         SET n.isDeleted = true

--- a/src/main/java/server/poptato/note/infra/JpaNoteRepository.java
+++ b/src/main/java/server/poptato/note/infra/JpaNoteRepository.java
@@ -42,6 +42,14 @@ public interface JpaNoteRepository extends JpaRepository<Note, Long> {
     @Query("""
         UPDATE Note n
         SET n.isDeleted = true
+        WHERE n.id = :noteId
+        """)
+    void softDeleteById(@Param("noteId") Long noteId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Note n
+        SET n.isDeleted = true
         WHERE n.userId = :userId
         """)
     void softDeleteByUserId(@Param("userId") Long userId);

--- a/src/main/java/server/poptato/note/infra/impl/NoteRepositoryImpl.java
+++ b/src/main/java/server/poptato/note/infra/impl/NoteRepositoryImpl.java
@@ -36,11 +36,6 @@ public class NoteRepositoryImpl implements NoteRepository {
     }
 
     @Override
-    public void delete(Note note) {
-        jpaNoteRepository.delete(note);
-    }
-
-    @Override
     public void softDeleteByUserId(Long userId) {
         jpaNoteRepository.softDeleteByUserId(userId);
     }

--- a/src/main/java/server/poptato/note/infra/impl/NoteRepositoryImpl.java
+++ b/src/main/java/server/poptato/note/infra/impl/NoteRepositoryImpl.java
@@ -39,4 +39,9 @@ public class NoteRepositoryImpl implements NoteRepository {
     public void delete(Note note) {
         jpaNoteRepository.delete(note);
     }
+
+    @Override
+    public void softDeleteByUserId(Long userId) {
+        jpaNoteRepository.softDeleteByUserId(userId);
+    }
 }

--- a/src/main/java/server/poptato/note/infra/impl/NoteRepositoryImpl.java
+++ b/src/main/java/server/poptato/note/infra/impl/NoteRepositoryImpl.java
@@ -36,6 +36,11 @@ public class NoteRepositoryImpl implements NoteRepository {
     }
 
     @Override
+    public void softDeleteById(Long noteId) {
+        jpaNoteRepository.softDeleteById(noteId);
+    }
+
+    @Override
     public void softDeleteByUserId(Long userId) {
         jpaNoteRepository.softDeleteByUserId(userId);
     }

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -87,8 +87,8 @@ public class TodoService {
     @Transactional
     public void deleteTodoById(Long userId, Long todoId) {
         userValidator.checkIsExistUser(userId);
-        Todo findTodo = validateAndReturnTodo(userId, todoId);
-        findTodo.softDelete();
+        validateAndReturnTodo(userId, todoId);
+        todoRepository.softDeleteById(todoId);
     }
 
     /**
@@ -429,11 +429,11 @@ public class TodoService {
 
         todoRepository.saveAll(completedTodos);
         todoRepository.saveAll(backloggedTodos);
-        // Soft Delete 처리
-        for (Todo todo : toDelete) {
-            todo.softDelete();
+        // Soft Delete 처리 (벌크 UPDATE)
+        if (!toDelete.isEmpty()) {
+            List<Long> toDeleteIds = toDelete.stream().map(Todo::getId).toList();
+            todoRepository.softDeleteByIds(toDeleteIds);
         }
-        todoRepository.saveAll(toDelete);
         entityManager.flush();
         entityManager.clear();
 

--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -88,7 +88,7 @@ public class TodoService {
     public void deleteTodoById(Long userId, Long todoId) {
         userValidator.checkIsExistUser(userId);
         Todo findTodo = validateAndReturnTodo(userId, todoId);
-        todoRepository.delete(findTodo);
+        findTodo.softDelete();
     }
 
     /**
@@ -429,7 +429,11 @@ public class TodoService {
 
         todoRepository.saveAll(completedTodos);
         todoRepository.saveAll(backloggedTodos);
-        todoRepository.deleteAll(toDelete);
+        // Soft Delete 처리
+        for (Todo todo : toDelete) {
+            todo.softDelete();
+        }
+        todoRepository.saveAll(toDelete);
         entityManager.flush();
         entityManager.clear();
 

--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -1,6 +1,22 @@
 package server.poptato.todo.domain.entity;
 
-import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,9 +25,6 @@ import server.poptato.category.domain.entity.Category;
 import server.poptato.global.dao.BaseEntity;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
 
 @Getter
 @Entity
@@ -223,9 +236,6 @@ public class Todo extends BaseEntity {
         this.backlogOrder = order;
     }
 
-    /**
-     * Soft Delete 처리
-     */
     public void softDelete() {
         this.isDeleted = true;
     }

--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -68,6 +68,9 @@ public class Todo extends BaseEntity {
     @Column(name = "backlog_order")
     private Integer backlogOrder;
 
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", insertable = false, updatable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Category category;
@@ -218,5 +221,12 @@ public class Todo extends BaseEntity {
 
     public void updateBacklogOrder(Integer order) {
         this.backlogOrder = order;
+    }
+
+    /**
+     * Soft Delete 처리
+     */
+    public void softDelete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -3,6 +3,8 @@ package server.poptato.todo.domain.entity;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
@@ -30,6 +32,7 @@ import server.poptato.todo.domain.value.Type;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "todo")
+@SQLRestriction("is_deleted = false")
 public class Todo extends BaseEntity {
 
     @Id

--- a/src/main/java/server/poptato/todo/domain/entity/Todo.java
+++ b/src/main/java/server/poptato/todo/domain/entity/Todo.java
@@ -238,8 +238,4 @@ public class Todo extends BaseEntity {
     public void updateBacklogOrder(Integer order) {
         this.backlogOrder = order;
     }
-
-    public void softDelete() {
-        this.isDeleted = true;
-    }
 }

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -55,6 +55,10 @@ public interface TodoRepository {
 
     void deleteAllByCategoryId(Long categoryId);
 
+    void softDeleteByUserId(Long userId);
+
+    void softDeleteByCategoryId(Long categoryId);
+
     List<Todo> findIncompleteTodayTodos(Long userId, TodayStatus todayStatus);
 
     List<Todo> findTodosByDeadLine(Long userId, LocalDate deadline);

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -25,10 +25,6 @@ public interface TodoRepository {
 
     Optional<Todo> findById(Long todoId);
 
-    void delete(Todo todo);
-
-    void deleteAll(List<Todo> todos);
-
     Todo save(Todo todo);
 
     void saveAll(List<Todo> todo);
@@ -52,8 +48,6 @@ public interface TodoRepository {
     Page<Todo> findHistories(Long userId, LocalDate localDate, Pageable pageable);
 
     List<Todo> findByType(Type type);
-
-    void deleteAllByCategoryId(Long categoryId);
 
     void softDeleteById(Long todoId);
 

--- a/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/TodoRepository.java
@@ -55,6 +55,10 @@ public interface TodoRepository {
 
     void deleteAllByCategoryId(Long categoryId);
 
+    void softDeleteById(Long todoId);
+
+    void softDeleteByIds(List<Long> todoIds);
+
     void softDeleteByUserId(Long userId);
 
     void softDeleteByCategoryId(Long categoryId);

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -226,6 +226,22 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
     @Query("""
         UPDATE Todo t
         SET t.isDeleted = true
+        WHERE t.id = :todoId
+    """)
+    void softDeleteById(@Param("todoId") Long todoId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Todo t
+        SET t.isDeleted = true
+        WHERE t.id IN :todoIds
+    """)
+    void softDeleteByIds(@Param("todoIds") List<Long> todoIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Todo t
+        SET t.isDeleted = true
         WHERE t.userId = :userId
     """)
     void softDeleteByUserId(@Param("userId") Long userId);

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -222,7 +222,7 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
 
     void deleteAllByCategoryId(Long categoryId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
         UPDATE Todo t
         SET t.isDeleted = true
@@ -230,7 +230,7 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
     """)
     void softDeleteByUserId(@Param("userId") Long userId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
         UPDATE Todo t
         SET t.isDeleted = true

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -220,8 +220,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
     """)
     List<Todo> findByType(@Param("type") Type type);
 
-    void deleteAllByCategoryId(Long categoryId);
-
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE Todo t

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -26,7 +26,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
           AND t.type = 'TODAY'
           AND t.todayStatus = 'COMPLETED'
           AND FUNCTION('DATE', c.dateTime) = :todayDate
-          AND t.isDeleted = false
         ORDER BY c.dateTime ASC
     """)
     List<Todo> findCompletedTodays(
@@ -42,7 +41,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
           AND t.type = :type
           AND t.todayDate = :todayDate
           AND t.todayStatus = :todayStatus
-          AND t.isDeleted = false
         ORDER BY t.todayOrder DESC
     """)
     List<Todo> findIncompleteTodays(
@@ -59,7 +57,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
           AND t.type = :type
           AND t.todayDate = :todayDate
           AND t.todayStatus = :todayStatus
-          AND t.isDeleted = false
         ORDER BY t.todayOrder DESC
     """)
     List<Todo> findIncompleteTodaysWithCategory(
@@ -78,7 +75,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
           AND t.type = 'TODAY'
           AND t.todayStatus = 'COMPLETED'
           AND FUNCTION('DATE', c.dateTime) = :todayDate
-          AND t.isDeleted = false
         ORDER BY c.dateTime ASC
     """)
     List<Todo> findCompletedTodaysWithCategory(
@@ -92,7 +88,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         WHERE t.userId = :userId
           AND t.type = :type
           AND t.todayStatus = :todayStatus
-          AND t.isDeleted = false
     """)
     Page<Todo> findByUserIdAndTypeAndTodayStatus(
             @Param("userId") Long userId,
@@ -105,7 +100,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         SELECT t
         FROM Todo t
         WHERE t.id = :id
-          AND t.isDeleted = false
     """)
     Optional<Todo> findById(@Param("id") Long id);
 
@@ -114,7 +108,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         FROM Todo t
         WHERE t.userId = :userId
           AND t.todayOrder IS NOT NULL
-          AND t.isDeleted = false
     """)
     Integer findMaxTodayOrderByUserIdOrZero(@Param("userId") Long userId);
 
@@ -123,7 +116,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         FROM Todo t
         WHERE t.userId = :userId
           AND t.todayOrder IS NOT NULL
-          AND t.isDeleted = false
     """)
     Integer findMinTodayOrderByUserIdOrZero(@Param("userId") Long userId);
 
@@ -132,7 +124,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         FROM Todo t
         WHERE t.userId = :userId
           AND t.backlogOrder IS NOT NULL
-          AND t.isDeleted = false
     """)
     Integer findMaxBacklogOrderByUserIdOrZero(@Param("userId") Long userId);
 
@@ -143,7 +134,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         WHERE t.userId = :userId
           AND t.type = :type
           AND (t.todayStatus != :status OR t.todayStatus IS NULL)
-          AND t.isDeleted = false
         ORDER BY t.backlogOrder DESC
     """)
     Page<Todo> findAllBacklogs(
@@ -159,7 +149,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         WHERE t.userId = :userId
           AND t.deadline = :localDate
           AND t.type IN ('BACKLOG', 'YESTERDAY')
-          AND t.isDeleted = false
     """)
     Page<Todo> findDeadlineBacklogs(
             @Param("userId") Long userId,
@@ -175,7 +164,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
           AND t.isBookmark = true
           AND t.type = :type
           AND (t.todayStatus != :status OR t.todayStatus IS NULL)
-          AND t.isDeleted = false
         ORDER BY t.backlogOrder DESC
     """)
     Page<Todo> findBookmarkBacklogs(
@@ -193,7 +181,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
           AND t.categoryId = :categoryId
           AND t.type = :type
           AND (t.todayStatus != :status OR t.todayStatus IS NULL)
-          AND t.isDeleted = false
         ORDER BY t.backlogOrder DESC
     """)
     Page<Todo> findBacklogsByCategoryId(
@@ -213,7 +200,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
             WHERE DATE(c.dateTime) = :localDate
         )
           AND t.userId = :userId
-          AND t.isDeleted = false
         ORDER BY (
             SELECT c.dateTime
             FROM CompletedDateTime c
@@ -231,7 +217,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         SELECT t
         FROM Todo t
         WHERE t.type = :type
-          AND t.isDeleted = false
     """)
     List<Todo> findByType(@Param("type") Type type);
 
@@ -258,7 +243,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         WHERE t.userId = :userId
           AND t.todayStatus = :todayStatus
           AND t.type = 'TODAY'
-          AND t.isDeleted = false
     """)
     List<Todo> findIncompleteTodayTodos(
             @Param("userId") Long userId,
@@ -270,7 +254,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         WHERE t.type = 'BACKLOG'
           AND t.userId = :userId
           AND t.deadline = :deadline
-          AND t.isDeleted = false
     """)
     List<Todo> findTodosByDeadLine(
             @Param("userId") Long userId,
@@ -283,7 +266,7 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         WHERE t.type = 'BACKLOG'
           AND r.day = :todayDay
           AND t.user_id = :userId
-          AND t.is_deleted = 0
+          AND t.is_deleted = false
     """, nativeQuery = true)
     List<Todo> findRoutineTodosByDay(
             @Param("userId") Long userId,
@@ -296,7 +279,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         WHERE t.userId = :userId
           AND t.type = 'YESTERDAY'
           AND t.todayStatus = 'INCOMPLETE'
-          AND t.isDeleted = false
         ORDER BY t.todayOrder DESC
     """)
     List<Todo> findIncompleteYesterdays(@Param("userId") Long userId);
@@ -310,7 +292,7 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
           AND YEAR(t.deadline) = :year
           AND MONTH(t.deadline) = :month
           AND t.type = 'BACKLOG'
-          AND t.is_deleted = 0
+          AND t.is_deleted = false
         GROUP BY t.deadline
         ORDER BY t.deadline
     """, nativeQuery = true)
@@ -326,7 +308,6 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         WHERE t.userId = :userId
           AND t.type = :type
           AND t.todayStatus = :todayStatus
-          AND t.isDeleted = false
     """)
     boolean existsByUserIdAndTypeAndTodayStatus(
             @Param("userId") Long userId,
@@ -338,7 +319,7 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         SELECT t.user_id AS userId, COALESCE(MAX(t.today_order), 0) AS maxOrder
         FROM todo t
         WHERE t.user_id IN (:userIds)
-          AND t.is_deleted = 0
+          AND t.is_deleted = false
         GROUP BY t.user_id
     """, nativeQuery = true)
     List<Tuple> findMaxTodayOrdersByUserIds(@Param("userIds") List<Long> userIds);

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -222,7 +222,7 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
 
     void deleteAllByCategoryId(Long categoryId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE Todo t
         SET t.isDeleted = true
@@ -230,10 +230,10 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
     """)
     void softDeleteByUserId(@Param("userId") Long userId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE Todo t
-        SET t.isDeleted = true
+        SET t.isDeleted = true, t.categoryId = null
         WHERE t.categoryId = :categoryId
     """)
     void softDeleteByCategoryId(@Param("categoryId") Long categoryId);

--- a/src/main/java/server/poptato/todo/infra/repository/impl/TodoRepositoryImpl.java
+++ b/src/main/java/server/poptato/todo/infra/repository/impl/TodoRepositoryImpl.java
@@ -125,6 +125,16 @@ public class TodoRepositoryImpl implements TodoRepository {
     }
 
     @Override
+    public void softDeleteById(Long todoId) {
+        jpaTodoRepository.softDeleteById(todoId);
+    }
+
+    @Override
+    public void softDeleteByIds(List<Long> todoIds) {
+        jpaTodoRepository.softDeleteByIds(todoIds);
+    }
+
+    @Override
     public void softDeleteByUserId(Long userId) {
         jpaTodoRepository.softDeleteByUserId(userId);
     }

--- a/src/main/java/server/poptato/todo/infra/repository/impl/TodoRepositoryImpl.java
+++ b/src/main/java/server/poptato/todo/infra/repository/impl/TodoRepositoryImpl.java
@@ -50,16 +50,6 @@ public class TodoRepositoryImpl implements TodoRepository {
     }
 
     @Override
-    public void delete(Todo todo) {
-        jpaTodoRepository.delete(todo);
-    }
-
-    @Override
-    public void deleteAll(List<Todo> todos) {
-        jpaTodoRepository.deleteAll(todos);
-    }
-
-    @Override
     public Todo save(Todo todo) {
         return jpaTodoRepository.save(todo);
     }
@@ -117,11 +107,6 @@ public class TodoRepositoryImpl implements TodoRepository {
     @Override
     public List<Todo> findByType(Type type) {
         return jpaTodoRepository.findByType(type);
-    }
-
-    @Override
-    public void deleteAllByCategoryId(Long categoryId) {
-        jpaTodoRepository.deleteAllByCategoryId(categoryId);
     }
 
     @Override

--- a/src/main/java/server/poptato/todo/infra/repository/impl/TodoRepositoryImpl.java
+++ b/src/main/java/server/poptato/todo/infra/repository/impl/TodoRepositoryImpl.java
@@ -125,6 +125,16 @@ public class TodoRepositoryImpl implements TodoRepository {
     }
 
     @Override
+    public void softDeleteByUserId(Long userId) {
+        jpaTodoRepository.softDeleteByUserId(userId);
+    }
+
+    @Override
+    public void softDeleteByCategoryId(Long categoryId) {
+        jpaTodoRepository.softDeleteByCategoryId(categoryId);
+    }
+
+    @Override
     public List<Todo> findIncompleteTodayTodos(Long userId, TodayStatus todayStatus) {
         return jpaTodoRepository.findIncompleteTodayTodos(userId, todayStatus);
     }

--- a/src/main/java/server/poptato/user/application/service/UserService.java
+++ b/src/main/java/server/poptato/user/application/service/UserService.java
@@ -42,16 +42,7 @@ public class UserService {
     private final MobileRepository mobileRepository;
     private final TodoRepository todoRepository;
     private final NoteRepository noteRepository;
-
-    /**
-     * 사용자 탈퇴 처리 메서드.
-     *
-     * 주어진 사용자 ID를 기반으로 탈퇴 요청을 처리합니다.
-     * 탈퇴 이유를 저장하고, 관련 데이터(할 일, 모바일 정보)를 삭제한 뒤 사용자를 삭제합니다.
-     *
-     * @param userId 사용자 ID
-     * @param requestDTO 탈퇴 요청 데이터
-     */
+	
     /**
      * 사용자 탈퇴 처리 메서드 (Soft Delete).
      *

--- a/src/main/java/server/poptato/user/application/service/UserService.java
+++ b/src/main/java/server/poptato/user/application/service/UserService.java
@@ -67,7 +67,7 @@ public class UserService {
         categoryRepository.softDeleteByUserId(userId);
         noteRepository.softDeleteByUserId(userId);
         mobileRepository.deleteByUserId(userId);  // mobile은 hard delete 유지
-        user.softDelete();
+        userRepository.softDeleteById(userId);
 
         jwtService.revokeAllRefreshTokens(userId);
     }

--- a/src/main/java/server/poptato/user/domain/entity/User.java
+++ b/src/main/java/server/poptato/user/domain/entity/User.java
@@ -1,5 +1,7 @@
 package server.poptato.user.domain.entity;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -21,6 +23,7 @@ import server.poptato.user.domain.value.SocialType;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")
+@SQLRestriction("is_deleted = false")
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/server/poptato/user/domain/entity/User.java
+++ b/src/main/java/server/poptato/user/domain/entity/User.java
@@ -75,11 +75,10 @@ public class User extends BaseEntity {
     }
     
     /**
-     * 소프트 삭제 처리.
-     * socialId를 변경하여 동일 소셜 계정으로 재가입 가능하도록 함.
+     * 탈퇴 시, socialId를 변경하여 동일 소셜 계정으로 재가입 가능하도록 함.
      */
     public void softDelete() {
-        this.isDeleted = true;
-        this.socialId = "DELETED_" + System.currentTimeMillis() + "_" + this.socialId;
+		this.socialId = "DELETED_" + System.currentTimeMillis() + "_" + this.socialId;
+		this.isDeleted = true;
     }
 }

--- a/src/main/java/server/poptato/user/domain/entity/User.java
+++ b/src/main/java/server/poptato/user/domain/entity/User.java
@@ -39,6 +39,9 @@ public class User extends BaseEntity {
     @Column(name = "is_push_alarm", nullable = false)
     private Boolean isPushAlarm;
 
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
     @Builder
     public User(SocialType socialType, String socialId, String name, String email, String imageUrl, Boolean isPushAlarm) {
         this.socialType = socialType;
@@ -62,5 +65,12 @@ public class User extends BaseEntity {
                 .imageUrl(imageUrl)
                 .isPushAlarm(true)
                 .build();
+    }
+
+    /**
+     * Soft Delete 처리
+     */
+    public void softDelete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/server/poptato/user/domain/entity/User.java
+++ b/src/main/java/server/poptato/user/domain/entity/User.java
@@ -1,13 +1,20 @@
 package server.poptato.user.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import server.poptato.auth.api.request.LoginRequestDto;
-import server.poptato.infra.oauth.SocialUserInfo;
 import server.poptato.global.dao.BaseEntity;
+import server.poptato.infra.oauth.SocialUserInfo;
 import server.poptato.user.domain.value.SocialType;
 
 @Getter
@@ -66,10 +73,7 @@ public class User extends BaseEntity {
                 .isPushAlarm(true)
                 .build();
     }
-
-    /**
-     * Soft Delete 처리
-     */
+    
     public void softDelete() {
         this.isDeleted = true;
     }

--- a/src/main/java/server/poptato/user/domain/entity/User.java
+++ b/src/main/java/server/poptato/user/domain/entity/User.java
@@ -76,12 +76,4 @@ public class User extends BaseEntity {
                 .isPushAlarm(true)
                 .build();
     }
-    
-    /**
-     * 탈퇴 시, socialId를 변경하여 동일 소셜 계정으로 재가입 가능하도록 함.
-     */
-    public void softDelete() {
-		this.socialId = "DELETED_" + System.currentTimeMillis() + "_" + this.socialId;
-		this.isDeleted = true;
-    }
 }

--- a/src/main/java/server/poptato/user/domain/entity/User.java
+++ b/src/main/java/server/poptato/user/domain/entity/User.java
@@ -74,7 +74,12 @@ public class User extends BaseEntity {
                 .build();
     }
     
+    /**
+     * 소프트 삭제 처리.
+     * socialId를 변경하여 동일 소셜 계정으로 재가입 가능하도록 함.
+     */
     public void softDelete() {
         this.isDeleted = true;
+        this.socialId = "DELETED_" + System.currentTimeMillis() + "_" + this.socialId;
     }
 }

--- a/src/main/java/server/poptato/user/domain/repository/UserRepository.java
+++ b/src/main/java/server/poptato/user/domain/repository/UserRepository.java
@@ -20,4 +20,6 @@ public interface UserRepository {
     List<User> findByIsPushAlarmTrue();
 
     long count();
+
+    void softDeleteById(Long userId);
 }

--- a/src/main/java/server/poptato/user/domain/repository/UserRepository.java
+++ b/src/main/java/server/poptato/user/domain/repository/UserRepository.java
@@ -11,8 +11,6 @@ public interface UserRepository {
 
     Optional<User> findById(Long userId);
 
-    void delete(User user);
-
     User save(User user);
 
     List<Long> findAllUserIds();

--- a/src/main/java/server/poptato/user/infra/repository/JpaUserRepository.java
+++ b/src/main/java/server/poptato/user/infra/repository/JpaUserRepository.java
@@ -11,9 +11,36 @@ import java.util.Optional;
 
 public interface JpaUserRepository extends UserRepository, JpaRepository<User, Long> {
 
-    @Query("SELECT u FROM User u WHERE u.socialId = :socialId")
+    @Query("""
+        SELECT u FROM User u
+        WHERE u.socialId = :socialId
+          AND u.isDeleted = false
+        """)
     Optional<User> findBySocialId(@Param("socialId") String socialId);
 
-    @Query("SELECT u.id FROM User u")
+    @Query("""
+        SELECT u.id FROM User u
+        WHERE u.isDeleted = false
+        """)
     List<Long> findAllUserIds();
+
+    @Query("""
+        SELECT u FROM User u
+        WHERE u.id = :id
+          AND u.isDeleted = false
+        """)
+    Optional<User> findById(@Param("id") Long id);
+
+    @Query("""
+        SELECT u FROM User u
+        WHERE u.isPushAlarm = true
+          AND u.isDeleted = false
+        """)
+    List<User> findByIsPushAlarmTrue();
+
+    @Query("""
+        SELECT COUNT(u) FROM User u
+        WHERE u.isDeleted = false
+        """)
+    long count();
 }

--- a/src/main/java/server/poptato/user/infra/repository/JpaUserRepository.java
+++ b/src/main/java/server/poptato/user/infra/repository/JpaUserRepository.java
@@ -1,6 +1,7 @@
 package server.poptato.user.infra.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import server.poptato.user.domain.entity.User;
@@ -38,4 +39,13 @@ public interface JpaUserRepository extends UserRepository, JpaRepository<User, L
         SELECT COUNT(u) FROM User u
         """)
     long count();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE User u
+        SET u.isDeleted = true,
+            u.socialId = CONCAT('DELETED_', u.id, '_', u.socialId)
+        WHERE u.id = :userId
+        """)
+    void softDeleteById(@Param("userId") Long userId);
 }

--- a/src/main/java/server/poptato/user/infra/repository/JpaUserRepository.java
+++ b/src/main/java/server/poptato/user/infra/repository/JpaUserRepository.java
@@ -14,33 +14,28 @@ public interface JpaUserRepository extends UserRepository, JpaRepository<User, L
     @Query("""
         SELECT u FROM User u
         WHERE u.socialId = :socialId
-          AND u.isDeleted = false
         """)
     Optional<User> findBySocialId(@Param("socialId") String socialId);
 
     @Query("""
         SELECT u.id FROM User u
-        WHERE u.isDeleted = false
         """)
     List<Long> findAllUserIds();
 
     @Query("""
         SELECT u FROM User u
         WHERE u.id = :id
-          AND u.isDeleted = false
         """)
     Optional<User> findById(@Param("id") Long id);
 
     @Query("""
         SELECT u FROM User u
         WHERE u.isPushAlarm = true
-          AND u.isDeleted = false
         """)
     List<User> findByIsPushAlarmTrue();
 
     @Query("""
         SELECT COUNT(u) FROM User u
-        WHERE u.isDeleted = false
         """)
     long count();
 }

--- a/src/test/java/server/poptato/category/application/CategoryServiceTest.java
+++ b/src/test/java/server/poptato/category/application/CategoryServiceTest.java
@@ -430,7 +430,7 @@ public class CategoryServiceTest extends ServiceTestConfig {
             categoryService.deleteCategory(userId, categoryId);
 
             // then
-            verify(category, times(1)).softDelete();
+            verify(categoryRepository, times(1)).softDeleteById(categoryId);
             verify(todoRepository, times(1)).softDeleteByCategoryId(categoryId);
         }
 

--- a/src/test/java/server/poptato/category/application/CategoryServiceTest.java
+++ b/src/test/java/server/poptato/category/application/CategoryServiceTest.java
@@ -417,8 +417,8 @@ public class CategoryServiceTest extends ServiceTestConfig {
     class DeleteCategory {
 
         @Test
-        @DisplayName("[SCN-SVC-CATEGORY-004][TC-DELETE-001] 정상 삭제 시 카테고리 삭제와 연관 Todo 삭제를 각각 한 번 수행한다.")
-        void delete_success_deletesCategoryAndTodosOnce() {
+        @DisplayName("[SCN-SVC-CATEGORY-004][TC-DELETE-001] 정상 삭제 시 카테고리 soft delete와 연관 Todo soft delete를 각각 한 번 수행한다.")
+        void delete_success_softDeletesCategoryAndTodosOnce() {
             // given
             Long userId = 10L;
             Long categoryId = 100L;
@@ -430,9 +430,8 @@ public class CategoryServiceTest extends ServiceTestConfig {
             categoryService.deleteCategory(userId, categoryId);
 
             // then
-            verify(categoryRepository, times(1)).delete(same(category));
-            verify(todoRepository, times(1)).deleteAllByCategoryId(categoryId);
-            verifyNoMoreInteractions(categoryRepository, todoRepository);
+            verify(category, times(1)).softDelete();
+            verify(todoRepository, times(1)).softDeleteByCategoryId(categoryId);
         }
 
         @Test

--- a/src/test/java/server/poptato/category/application/CategoryServiceTest.java
+++ b/src/test/java/server/poptato/category/application/CategoryServiceTest.java
@@ -467,8 +467,7 @@ public class CategoryServiceTest extends ServiceTestConfig {
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining(CategoryErrorStatus._CATEGORY_NOT_EXIST.getMessage());
 
-            verify(categoryRepository, never()).delete(any());
-            verify(todoRepository, never()).deleteAllByCategoryId(anyLong());
+            verify(todoRepository, never()).softDeleteByCategoryId(anyLong());
         }
     }
 

--- a/src/test/java/server/poptato/category/domain/entity/CategoryTest.java
+++ b/src/test/java/server/poptato/category/domain/entity/CategoryTest.java
@@ -8,25 +8,7 @@ import org.junit.jupiter.api.Test;
 class CategoryTest {
 
     @Test
-    @DisplayName("[TC-ENTITY-001] softDelete 호출 시 isDeleted가 true로 변경된다")
-    void softDelete_setsIsDeletedTrue() {
-        // given
-        Category category = Category.builder()
-                .userId(1L)
-                .emojiId(1L)
-                .categoryOrder(1)
-                .name("test")
-                .build();
-
-        // when
-        category.softDelete();
-
-        // then
-        assertThat(category.isDeleted()).isTrue();
-    }
-
-    @Test
-    @DisplayName("[TC-ENTITY-002] isDeleted 기본값은 false이다")
+    @DisplayName("[TC-ENTITY-001] isDeleted 기본값은 false이다")
     void isDeleted_defaultIsFalse() {
         // given
         Category category = Category.builder()

--- a/src/test/java/server/poptato/category/domain/entity/CategoryTest.java
+++ b/src/test/java/server/poptato/category/domain/entity/CategoryTest.java
@@ -1,0 +1,42 @@
+package server.poptato.category.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CategoryTest {
+
+    @Test
+    @DisplayName("[TC-ENTITY-001] softDelete 호출 시 isDeleted가 true로 변경된다")
+    void softDelete_setsIsDeletedTrue() {
+        // given
+        Category category = Category.builder()
+                .userId(1L)
+                .emojiId(1L)
+                .categoryOrder(1)
+                .name("test")
+                .build();
+
+        // when
+        category.softDelete();
+
+        // then
+        assertThat(category.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[TC-ENTITY-002] isDeleted 기본값은 false이다")
+    void isDeleted_defaultIsFalse() {
+        // given
+        Category category = Category.builder()
+                .userId(1L)
+                .emojiId(1L)
+                .categoryOrder(1)
+                .name("test")
+                .build();
+
+        // then
+        assertThat(category.isDeleted()).isFalse();
+    }
+}

--- a/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
+++ b/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
@@ -36,9 +36,13 @@ public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
     }
 
     private Boolean getIsDeleted(Long id) {
-        return (Boolean) tem.getEntityManager().createNativeQuery(
+        Object result = tem.getEntityManager().createNativeQuery(
                 "SELECT is_deleted FROM category WHERE id = :id"
         ).setParameter("id", id).getSingleResult();
+        if (result instanceof Boolean) {
+            return (Boolean) result;
+        }
+        return ((Number) result).intValue() == 1;
     }
 
     @Nested
@@ -199,7 +203,7 @@ public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
             // given
             Long userId = 800L;
             seedAndReturn(userId, 1, "active-cat");
-            Category deletedCat = seedAndReturn(userId, 2, "deleted-cat");
+            seedAndReturn(userId, 2, "deleted-cat");
 
             jpaCategoryRepository.softDeleteByUserId(userId);
             tem.flush();

--- a/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
+++ b/src/test/java/server/poptato/category/infra/JpaCategoryRepositoryTest.java
@@ -1,6 +1,6 @@
 package server.poptato.category.infra;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 
@@ -33,6 +33,12 @@ public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
         tem.persist(c);
         tem.flush();
         tem.clear();
+    }
+
+    private Boolean getIsDeleted(Long id) {
+        return (Boolean) tem.getEntityManager().createNativeQuery(
+                "SELECT is_deleted FROM category WHERE id = :id"
+        ).setParameter("id", id).getSingleResult();
     }
 
     @Nested
@@ -162,14 +168,10 @@ public class JpaCategoryRepositoryTest extends DatabaseTestConfig {
             tem.flush();
             tem.clear();
 
-            // then
-            Category found1 = tem.find(Category.class, cat1.getId());
-            Category found2 = tem.find(Category.class, cat2.getId());
-            Category foundOther = tem.find(Category.class, otherCat.getId());
-
-            assertThat(found1.isDeleted()).isTrue();
-            assertThat(found2.isDeleted()).isTrue();
-            assertThat(foundOther.isDeleted()).isFalse();
+            // then - Native Query로 is_deleted 값 직접 확인 (@SQLRestriction 우회)
+            assertThat(getIsDeleted(cat1.getId())).isTrue();
+            assertThat(getIsDeleted(cat2.getId())).isTrue();
+            assertThat(getIsDeleted(otherCat.getId())).isFalse();
         }
     }
 }

--- a/src/test/java/server/poptato/note/application/NoteServiceTest.java
+++ b/src/test/java/server/poptato/note/application/NoteServiceTest.java
@@ -245,7 +245,7 @@ public class NoteServiceTest extends ServiceTestConfig {
             // then
             verify(userValidator).checkIsExistUser(userId);
             verify(noteRepository).findByIdAndUserId(noteId, userId);
-            verify(note).softDelete();
+            verify(noteRepository).softDeleteById(noteId);
         }
 
         @Test

--- a/src/test/java/server/poptato/note/application/NoteServiceTest.java
+++ b/src/test/java/server/poptato/note/application/NoteServiceTest.java
@@ -230,7 +230,7 @@ public class NoteServiceTest extends ServiceTestConfig {
     class DeleteNote {
 
         @Test
-        @DisplayName("[TC-DELETE-001] 노트를 정상적으로 삭제한다")
+        @DisplayName("[TC-DELETE-001] 노트를 정상적으로 삭제한다 (Soft Delete)")
         void deleteNote_success() {
             // given
             Long userId = 1L;
@@ -245,7 +245,7 @@ public class NoteServiceTest extends ServiceTestConfig {
             // then
             verify(userValidator).checkIsExistUser(userId);
             verify(noteRepository).findByIdAndUserId(noteId, userId);
-            verify(noteRepository).delete(note);
+            verify(note).softDelete();
         }
 
         @Test
@@ -264,7 +264,6 @@ public class NoteServiceTest extends ServiceTestConfig {
 
             verify(userValidator).checkIsExistUser(userId);
             verify(noteRepository).findByIdAndUserId(noteId, userId);
-            verify(noteRepository, never()).delete(any());
         }
     }
 }

--- a/src/test/java/server/poptato/note/domain/entity/NoteTest.java
+++ b/src/test/java/server/poptato/note/domain/entity/NoteTest.java
@@ -1,0 +1,36 @@
+package server.poptato.note.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NoteTest {
+
+    @Test
+    @DisplayName("[TC-ENTITY-001] softDelete 호출 시 isDeleted가 true로 변경된다")
+    void softDelete_setsIsDeletedTrue() {
+        // given
+        Note note = Note.builder()
+                .userId(1L)
+                .build();
+
+        // when
+        note.softDelete();
+
+        // then
+        assertThat(note.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[TC-ENTITY-002] isDeleted 기본값은 false이다")
+    void isDeleted_defaultIsFalse() {
+        // given
+        Note note = Note.builder()
+                .userId(1L)
+                .build();
+
+        // then
+        assertThat(note.isDeleted()).isFalse();
+    }
+}

--- a/src/test/java/server/poptato/note/domain/entity/NoteTest.java
+++ b/src/test/java/server/poptato/note/domain/entity/NoteTest.java
@@ -8,22 +8,7 @@ import org.junit.jupiter.api.Test;
 class NoteTest {
 
     @Test
-    @DisplayName("[TC-ENTITY-001] softDelete 호출 시 isDeleted가 true로 변경된다")
-    void softDelete_setsIsDeletedTrue() {
-        // given
-        Note note = Note.builder()
-                .userId(1L)
-                .build();
-
-        // when
-        note.softDelete();
-
-        // then
-        assertThat(note.isDeleted()).isTrue();
-    }
-
-    @Test
-    @DisplayName("[TC-ENTITY-002] isDeleted 기본값은 false이다")
+    @DisplayName("[TC-ENTITY-001] isDeleted 기본값은 false이다")
     void isDeleted_defaultIsFalse() {
         // given
         Note note = Note.builder()

--- a/src/test/java/server/poptato/note/infra/JpaNoteRepositoryTest.java
+++ b/src/test/java/server/poptato/note/infra/JpaNoteRepositoryTest.java
@@ -29,6 +29,12 @@ public class JpaNoteRepositoryTest extends DatabaseTestConfig {
         return note;
     }
 
+    private Boolean getIsDeleted(Long id) {
+        return (Boolean) tem.getEntityManager().createNativeQuery(
+                "SELECT is_deleted FROM note WHERE id = :id"
+        ).setParameter("id", id).getSingleResult();
+    }
+
     @Nested
     @DisplayName("[SCN-REP-NOTE-001] Soft Delete 테스트")
     @TestMethodOrder(MethodOrderer.DisplayName.class)
@@ -50,14 +56,10 @@ public class JpaNoteRepositoryTest extends DatabaseTestConfig {
             tem.flush();
             tem.clear();
 
-            // then
-            Note found1 = tem.find(Note.class, note1.getId());
-            Note found2 = tem.find(Note.class, note2.getId());
-            Note foundOther = tem.find(Note.class, otherNote.getId());
-
-            assertThat(found1.isDeleted()).isTrue();
-            assertThat(found2.isDeleted()).isTrue();
-            assertThat(foundOther.isDeleted()).isFalse();
+            // then - Native Query로 is_deleted 값 직접 확인 (@SQLRestriction 우회)
+            assertThat(getIsDeleted(note1.getId())).isTrue();
+            assertThat(getIsDeleted(note2.getId())).isTrue();
+            assertThat(getIsDeleted(otherNote.getId())).isFalse();
         }
     }
 }

--- a/src/test/java/server/poptato/note/infra/JpaNoteRepositoryTest.java
+++ b/src/test/java/server/poptato/note/infra/JpaNoteRepositoryTest.java
@@ -30,9 +30,13 @@ public class JpaNoteRepositoryTest extends DatabaseTestConfig {
     }
 
     private Boolean getIsDeleted(Long id) {
-        return (Boolean) tem.getEntityManager().createNativeQuery(
+        Object result = tem.getEntityManager().createNativeQuery(
                 "SELECT is_deleted FROM note WHERE id = :id"
         ).setParameter("id", id).getSingleResult();
+        if (result instanceof Boolean) {
+            return (Boolean) result;
+        }
+        return ((Number) result).intValue() == 1;
     }
 
     @Nested

--- a/src/test/java/server/poptato/note/infra/JpaNoteRepositoryTest.java
+++ b/src/test/java/server/poptato/note/infra/JpaNoteRepositoryTest.java
@@ -1,0 +1,63 @@
+package server.poptato.note.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import server.poptato.configuration.DatabaseTestConfig;
+import server.poptato.configuration.MySqlDataJpaTest;
+import server.poptato.note.domain.entity.Note;
+
+@MySqlDataJpaTest
+public class JpaNoteRepositoryTest extends DatabaseTestConfig {
+
+    @Autowired
+    private JpaNoteRepository jpaNoteRepository;
+
+    private Note createNote(Long userId) {
+        Note note = Note.builder()
+                .userId(userId)
+                .build();
+        tem.persist(note);
+        tem.flush();
+        tem.clear();
+        return note;
+    }
+
+    @Nested
+    @DisplayName("[SCN-REP-NOTE-001] Soft Delete 테스트")
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    class SoftDeleteTests {
+
+        @Test
+        @DisplayName("[TC-SOFT-DELETE-001] softDeleteByUserId 호출 시 해당 유저의 모든 Note가 soft delete 된다")
+        void softDeleteByUserId_deletesAllUserNotes() {
+            // given
+            Long userId = 100L;
+            Long otherUserId = 200L;
+
+            Note note1 = createNote(userId);
+            Note note2 = createNote(userId);
+            Note otherNote = createNote(otherUserId);
+
+            // when
+            jpaNoteRepository.softDeleteByUserId(userId);
+            tem.flush();
+            tem.clear();
+
+            // then
+            Note found1 = tem.find(Note.class, note1.getId());
+            Note found2 = tem.find(Note.class, note2.getId());
+            Note foundOther = tem.find(Note.class, otherNote.getId());
+
+            assertThat(found1.isDeleted()).isTrue();
+            assertThat(found2.isDeleted()).isTrue();
+            assertThat(foundOther.isDeleted()).isFalse();
+        }
+    }
+}

--- a/src/test/java/server/poptato/note/infra/NoteRepositoryImplTest.java
+++ b/src/test/java/server/poptato/note/infra/NoteRepositoryImplTest.java
@@ -1,0 +1,66 @@
+package server.poptato.note.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import server.poptato.configuration.DatabaseTestConfig;
+import server.poptato.configuration.MySqlDataJpaTest;
+import server.poptato.note.domain.entity.Note;
+import server.poptato.note.domain.repository.NoteRepository;
+import server.poptato.note.infra.impl.NoteRepositoryImpl;
+
+@MySqlDataJpaTest
+@Import(NoteRepositoryImpl.class)
+public class NoteRepositoryImplTest extends DatabaseTestConfig {
+
+    @Autowired
+    private NoteRepository noteRepository;
+
+    private Note createNote(Long userId) {
+        Note note = Note.builder()
+                .userId(userId)
+                .build();
+        tem.persist(note);
+        tem.flush();
+        tem.clear();
+        return note;
+    }
+
+    private Boolean getIsDeleted(Long id) {
+        return (Boolean) tem.getEntityManager().createNativeQuery(
+                "SELECT is_deleted FROM note WHERE id = :id"
+        ).setParameter("id", id).getSingleResult();
+    }
+
+    @Nested
+    @DisplayName("[SCN-REP-IMPL-NOTE-001] NoteRepositoryImpl Soft Delete 테스트")
+    class SoftDeleteTests {
+
+        @Test
+        @DisplayName("[TC-IMPL-001] softDeleteByUserId 호출 시 해당 유저의 모든 Note가 soft delete 된다")
+        void softDeleteByUserId_deletesAllUserNotes() {
+            // given
+            Long userId = 1000L;
+            Long otherUserId = 2000L;
+
+            Note note1 = createNote(userId);
+            Note note2 = createNote(userId);
+            Note otherNote = createNote(otherUserId);
+
+            // when
+            noteRepository.softDeleteByUserId(userId);
+            tem.flush();
+            tem.clear();
+
+            // then
+            assertThat(getIsDeleted(note1.getId())).isTrue();
+            assertThat(getIsDeleted(note2.getId())).isTrue();
+            assertThat(getIsDeleted(otherNote.getId())).isFalse();
+        }
+    }
+}

--- a/src/test/java/server/poptato/note/infra/NoteRepositoryImplTest.java
+++ b/src/test/java/server/poptato/note/infra/NoteRepositoryImplTest.java
@@ -32,9 +32,13 @@ public class NoteRepositoryImplTest extends DatabaseTestConfig {
     }
 
     private Boolean getIsDeleted(Long id) {
-        return (Boolean) tem.getEntityManager().createNativeQuery(
+        Object result = tem.getEntityManager().createNativeQuery(
                 "SELECT is_deleted FROM note WHERE id = :id"
         ).setParameter("id", id).getSingleResult();
+        if (result instanceof Boolean) {
+            return (Boolean) result;
+        }
+        return ((Number) result).intValue() == 1;
     }
 
     @Nested

--- a/src/test/java/server/poptato/note/infra/NoteRepositoryImplTest.java
+++ b/src/test/java/server/poptato/note/infra/NoteRepositoryImplTest.java
@@ -66,5 +66,23 @@ public class NoteRepositoryImplTest extends DatabaseTestConfig {
             assertThat(getIsDeleted(note2.getId())).isTrue();
             assertThat(getIsDeleted(otherNote.getId())).isFalse();
         }
+
+        @Test
+        @DisplayName("[TC-IMPL-002] softDeleteById 호출 시 해당 Note가 soft delete 된다")
+        void softDeleteById_deletesSingleNote() {
+            // given
+            Long userId = 1000L;
+            Note note1 = createNote(userId);
+            Note note2 = createNote(userId);
+
+            // when
+            noteRepository.softDeleteById(note1.getId());
+            tem.flush();
+            tem.clear();
+
+            // then
+            assertThat(getIsDeleted(note1.getId())).isTrue();
+            assertThat(getIsDeleted(note2.getId())).isFalse();
+        }
     }
 }

--- a/src/test/java/server/poptato/todo/application/TodoBatchServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoBatchServiceTest.java
@@ -1,0 +1,145 @@
+package server.poptato.todo.application;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.todo.domain.entity.Todo;
+import server.poptato.todo.domain.repository.TodoRepository;
+import server.poptato.todo.domain.value.TodayStatus;
+import server.poptato.todo.domain.value.Type;
+import server.poptato.user.domain.repository.UserRepository;
+
+class TodoBatchServiceTest extends ServiceTestConfig {
+
+    @Mock
+    private TodoRepository todoRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TodoService todoService;
+
+    @InjectMocks
+    private TodoBatchService todoBatchService;
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-BATCH-001] 오늘 할 일 상태를 업데이트한다")
+    class UpdateTodayTodosAndSave {
+
+        @Test
+        @DisplayName("[TC-BATCH-001] 완료된 반복 할 일은 백로그로 이동")
+        void updateTodayTodos_completedRepeatToBacklog() {
+            // given
+            Long userId = 1L;
+            Todo completedRepeatTodo = mock(Todo.class);
+            when(completedRepeatTodo.getUserId()).thenReturn(userId);
+            when(completedRepeatTodo.getTodayStatus()).thenReturn(TodayStatus.COMPLETED);
+            when(completedRepeatTodo.isRepeat()).thenReturn(true);
+
+            when(todoRepository.findByType(Type.TODAY)).thenReturn(List.of(completedRepeatTodo));
+            when(todoRepository.findMaxBacklogOrderByUserIdOrZero(userId)).thenReturn(5);
+
+            // when
+            todoBatchService.updateTodayTodosAndSave();
+
+            // then
+            verify(completedRepeatTodo).updateType(Type.BACKLOG);
+            verify(completedRepeatTodo).updateTodayStatus(null);
+            verify(completedRepeatTodo).updateTodayOrder(null);
+            verify(completedRepeatTodo).updateBacklogOrder(6);
+            verify(todoRepository).save(completedRepeatTodo);
+        }
+
+        @Test
+        @DisplayName("[TC-BATCH-002] 완료된 루틴 할 일은 백로그로 이동")
+        void updateTodayTodos_completedRoutineToBacklog() {
+            // given
+            Long userId = 1L;
+            Todo completedRoutineTodo = mock(Todo.class);
+            when(completedRoutineTodo.getUserId()).thenReturn(userId);
+            when(completedRoutineTodo.getTodayStatus()).thenReturn(TodayStatus.COMPLETED);
+            when(completedRoutineTodo.isRepeat()).thenReturn(false);
+            when(completedRoutineTodo.isRoutine()).thenReturn(true);
+
+            when(todoRepository.findByType(Type.TODAY)).thenReturn(List.of(completedRoutineTodo));
+            when(todoRepository.findMaxBacklogOrderByUserIdOrZero(userId)).thenReturn(3);
+
+            // when
+            todoBatchService.updateTodayTodosAndSave();
+
+            // then
+            verify(completedRoutineTodo).updateType(Type.BACKLOG);
+            verify(completedRoutineTodo).updateBacklogOrder(4);
+            verify(todoRepository).save(completedRoutineTodo);
+        }
+
+        @Test
+        @DisplayName("[TC-BATCH-003] 미완료 할 일은 어제로 변경")
+        void updateTodayTodos_incompleteToYesterday() {
+            // given
+            Long userId = 1L;
+            Todo incompleteTodo = mock(Todo.class);
+            when(incompleteTodo.getUserId()).thenReturn(userId);
+            when(incompleteTodo.getTodayStatus()).thenReturn(TodayStatus.INCOMPLETE);
+
+            when(todoRepository.findByType(Type.TODAY)).thenReturn(List.of(incompleteTodo));
+            when(todoRepository.findMaxBacklogOrderByUserIdOrZero(userId)).thenReturn(2);
+
+            // when
+            todoBatchService.updateTodayTodosAndSave();
+
+            // then
+            verify(incompleteTodo).updateType(Type.YESTERDAY);
+            verify(incompleteTodo).updateTodayOrder(null);
+            verify(incompleteTodo).updateBacklogOrder(3);
+            verify(todoRepository).save(incompleteTodo);
+        }
+
+        @Test
+        @DisplayName("[TC-BATCH-004] 오늘 할 일이 없는 경우")
+        void updateTodayTodos_emptyList() {
+            // given
+            when(todoRepository.findByType(Type.TODAY)).thenReturn(List.of());
+
+            // when
+            todoBatchService.updateTodayTodosAndSave();
+
+            // then
+            verify(todoRepository).findByType(Type.TODAY);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-BATCH-002] 마감기한/요일 반복 할 일을 오늘로 변경한다")
+    class UpdateDeadlineTodos {
+
+        @Test
+        @DisplayName("[TC-DDL-001] 마감기한 할 일 업데이트")
+        void updateDeadlineTodos_success() {
+            // given
+            ReflectionTestUtils.setField(todoBatchService, "batchSize", 100);
+            List<Long> userIds = List.of(1L, 2L, 3L);
+            when(userRepository.findAllUserIds()).thenReturn(userIds);
+            doNothing().when(todoService).processUpdateDeadlineTodos(any(LocalDate.class), anyList());
+
+            // when
+            todoBatchService.updateDeadlineTodos();
+
+            // then
+            verify(userRepository).findAllUserIds();
+            verify(todoService).processUpdateDeadlineTodos(any(LocalDate.class), anyList());
+        }
+    }
+}

--- a/src/test/java/server/poptato/todo/application/TodoSchedulerTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoSchedulerTest.java
@@ -1,0 +1,30 @@
+package server.poptato.todo.application;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import server.poptato.configuration.ServiceTestConfig;
+
+class TodoSchedulerTest extends ServiceTestConfig {
+
+    @Mock
+    private TodoBatchService todoBatchService;
+
+    @InjectMocks
+    private TodoScheduler todoScheduler;
+
+    @Test
+    @DisplayName("[TC-SCH-001] 스케줄러 실행 시 배치 서비스 메서드가 호출된다")
+    void updateTodoType_callsBatchServiceMethods() {
+        // when
+        todoScheduler.updateTodoType();
+
+        // then
+        verify(todoBatchService).updateTodayTodosAndSave();
+        verify(todoBatchService).updateDeadlineTodos();
+    }
+}

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -934,7 +934,7 @@ class TodoServiceTest extends ServiceTestConfig {
     }
 
     @Nested
-    @DisplayName("[SCN-SVC-TODO-012] 어제 할 일을 체크한다")
+    @DisplayName("[SCN-SVC-TODO-017] 어제 할 일을 체크한다")
     class CheckYesterdayTodos {
 
         @Test

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -1,0 +1,78 @@
+package server.poptato.todo.application;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import server.poptato.category.domain.repository.CategoryRepository;
+import server.poptato.category.validator.CategoryValidator;
+import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.emoji.domain.repository.EmojiRepository;
+import server.poptato.todo.domain.entity.Todo;
+import server.poptato.todo.domain.repository.CompletedDateTimeRepository;
+import server.poptato.todo.domain.repository.RoutineRepository;
+import server.poptato.todo.domain.repository.TimeAlarmRepository;
+import server.poptato.todo.domain.repository.TodoRepository;
+import server.poptato.user.validator.UserValidator;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class TodoServiceTest extends ServiceTestConfig {
+
+    @Mock
+    private UserValidator userValidator;
+    @Mock
+    private CategoryValidator categoryValidator;
+    @Mock
+    private TodoRepository todoRepository;
+    @Mock
+    private TimeAlarmRepository timeAlarmRepository;
+    @Mock
+    private RoutineRepository routineRepository;
+    @Mock
+    private CompletedDateTimeRepository completedDateTimeRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private EmojiRepository emojiRepository;
+    @Mock
+    private EntityManager entityManager;
+
+    @InjectMocks
+    private TodoService todoService;
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    @DisplayName("[SCN-SVC-TODO-001] 할 일을 삭제한다 (Soft Delete)")
+    class DeleteTodo {
+
+        @Test
+        @DisplayName("[TC-DELETE-001] 할 일을 정상적으로 삭제한다 (Soft Delete)")
+        void deleteTodoById_success() {
+            // given
+            Long userId = 1L;
+            Long todoId = 10L;
+
+            Todo todo = mock(Todo.class);
+            given(todo.getUserId()).willReturn(userId);
+            given(todoRepository.findById(todoId)).willReturn(Optional.of(todo));
+
+            // when
+            todoService.deleteTodoById(userId, todoId);
+
+            // then
+            verify(userValidator).checkIsExistUser(userId);
+            verify(todoRepository).findById(todoId);
+            verify(todo).softDelete();
+        }
+    }
+
+}

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -1,78 +1,934 @@
 package server.poptato.todo.application;
 
-import jakarta.persistence.EntityManager;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jakarta.persistence.EntityManager;
+import server.poptato.category.domain.entity.Category;
 import server.poptato.category.domain.repository.CategoryRepository;
 import server.poptato.category.validator.CategoryValidator;
 import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.emoji.domain.entity.Emoji;
 import server.poptato.emoji.domain.repository.EmojiRepository;
+import server.poptato.global.exception.CustomException;
+import server.poptato.todo.api.request.ContentUpdateRequestDto;
+import server.poptato.todo.api.request.DeadlineUpdateRequestDto;
+import server.poptato.todo.api.request.RoutineUpdateRequestDto;
+import server.poptato.todo.api.request.SwipeRequestDto;
+import server.poptato.todo.api.request.TimeUpdateRequestDto;
+import server.poptato.todo.api.request.TodoCategoryUpdateRequestDto;
+import server.poptato.todo.api.request.TodoDragAndDropRequestDto;
+import server.poptato.todo.application.response.PaginatedHistoryResponseDto;
+import server.poptato.todo.application.response.TodoDetailResponseDto;
+import server.poptato.todo.domain.entity.CompletedDateTime;
+import server.poptato.todo.domain.entity.TimeAlarm;
 import server.poptato.todo.domain.entity.Todo;
 import server.poptato.todo.domain.repository.CompletedDateTimeRepository;
 import server.poptato.todo.domain.repository.RoutineRepository;
 import server.poptato.todo.domain.repository.TimeAlarmRepository;
 import server.poptato.todo.domain.repository.TodoRepository;
+import server.poptato.todo.domain.value.TodayStatus;
+import server.poptato.todo.domain.value.Type;
+import server.poptato.todo.status.TodoErrorStatus;
+import server.poptato.user.domain.value.MobileType;
 import server.poptato.user.validator.UserValidator;
-
-import java.util.Optional;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 class TodoServiceTest extends ServiceTestConfig {
 
-    @Mock
-    private UserValidator userValidator;
-    @Mock
-    private CategoryValidator categoryValidator;
-    @Mock
-    private TodoRepository todoRepository;
-    @Mock
-    private TimeAlarmRepository timeAlarmRepository;
-    @Mock
-    private RoutineRepository routineRepository;
-    @Mock
-    private CompletedDateTimeRepository completedDateTimeRepository;
-    @Mock
-    private CategoryRepository categoryRepository;
-    @Mock
-    private EmojiRepository emojiRepository;
-    @Mock
-    private EntityManager entityManager;
+    @Mock private UserValidator userValidator;
+    @Mock private CategoryValidator categoryValidator;
+    @Mock private TodoRepository todoRepository;
+    @Mock private TimeAlarmRepository timeAlarmRepository;
+    @Mock private RoutineRepository routineRepository;
+    @Mock private CompletedDateTimeRepository completedDateTimeRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private EmojiRepository emojiRepository;
+    @Mock private EntityManager entityManager;
 
     @InjectMocks
     private TodoService todoService;
 
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(todoService, "entityManager", entityManager);
+    }
+
+    @Captor
+    private ArgumentCaptor<Todo> todoCaptor;
+
+    @Captor
+    private ArgumentCaptor<CompletedDateTime> completedDateTimeCaptor;
+
+    @Captor
+    private ArgumentCaptor<TimeAlarm> timeAlarmCaptor;
+
     @Nested
-    @TestMethodOrder(MethodOrderer.DisplayName.class)
-    @DisplayName("[SCN-SVC-TODO-001] 할 일을 삭제한다 (Soft Delete)")
-    class DeleteTodo {
+    @DisplayName("[SCN-SVC-TODO-001] 할 일을 삭제한다")
+    class DeleteTodoById {
 
         @Test
-        @DisplayName("[TC-DELETE-001] 할 일을 정상적으로 삭제한다 (Soft Delete)")
+        @DisplayName("[TC-DEL-001] 성공: 본인의 할 일을 삭제한다 (soft delete)")
         void deleteTodoById_success() {
             // given
             Long userId = 1L;
-            Long todoId = 10L;
-
+            Long todoId = 100L;
             Todo todo = mock(Todo.class);
-            given(todo.getUserId()).willReturn(userId);
-            given(todoRepository.findById(todoId)).willReturn(Optional.of(todo));
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
 
             // when
             todoService.deleteTodoById(userId, todoId);
 
             // then
-            verify(userValidator).checkIsExistUser(userId);
-            verify(todoRepository).findById(todoId);
             verify(todo).softDelete();
+        }
+
+        @Test
+        @DisplayName("[TC-DEL-002] 실패: 존재하지 않는 할 일")
+        void deleteTodoById_todoNotExist() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> todoService.deleteTodoById(userId, todoId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", TodoErrorStatus._TODO_NOT_EXIST);
+        }
+
+        @Test
+        @DisplayName("[TC-DEL-003] 실패: 다른 사용자의 할 일")
+        void deleteTodoById_userNotMatch() {
+            // given
+            Long userId = 1L;
+            Long otherUserId = 2L;
+            Long todoId = 100L;
+            Todo todo = createTodo(otherUserId, todoId, Type.BACKLOG);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            // when & then
+            assertThatThrownBy(() -> todoService.deleteTodoById(userId, todoId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", TodoErrorStatus._TODO_USER_NOT_MATCH);
         }
     }
 
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-002] 북마크를 토글한다")
+    class ToggleIsBookmark {
+
+        @Test
+        @DisplayName("[TC-BMK-001] 성공: 북마크를 활성화한다")
+        void toggleIsBookmark_enable() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            // when
+            todoService.toggleIsBookmark(userId, todoId);
+
+            // then
+            verify(todo).toggleBookmark();
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-003] 스와이프한다")
+    class Swipe {
+
+        @Test
+        @DisplayName("[TC-SWP-001] 백로그 -> 오늘로 스와이프")
+        void swipe_backlogToToday() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+            when(todo.getType()).thenReturn(Type.BACKLOG);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(todoRepository.findMaxTodayOrderByUserIdOrZero(userId)).thenReturn(5);
+
+            SwipeRequestDto requestDto = new SwipeRequestDto(todoId);
+
+            // when
+            todoService.swipe(userId, requestDto);
+
+            // then
+            verify(todo).changeToToday(5);
+        }
+
+        @Test
+        @DisplayName("[TC-SWP-002] 오늘 -> 백로그로 스와이프 (미완료 상태)")
+        void swipe_todayToBacklog_incomplete() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+            when(todo.getType()).thenReturn(Type.TODAY);
+            when(todo.getTodayStatus()).thenReturn(TodayStatus.INCOMPLETE);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(todoRepository.findMaxBacklogOrderByUserIdOrZero(userId)).thenReturn(10);
+
+            SwipeRequestDto requestDto = new SwipeRequestDto(todoId);
+
+            // when
+            todoService.swipe(userId, requestDto);
+
+            // then
+            verify(todo).changeToBacklog(10);
+        }
+
+        @Test
+        @DisplayName("[TC-SWP-003] 실패: 이미 완료된 할 일 스와이프 시도")
+        void swipe_alreadyCompleted() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+            when(todo.getType()).thenReturn(Type.TODAY);
+            when(todo.getTodayStatus()).thenReturn(TodayStatus.COMPLETED);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            SwipeRequestDto requestDto = new SwipeRequestDto(todoId);
+
+            // when & then
+            assertThatThrownBy(() -> todoService.swipe(userId, requestDto))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", TodoErrorStatus._ALREADY_COMPLETED_TODO);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-004] 드래그 앤 드롭으로 순서를 변경한다")
+    class DragAndDrop {
+
+        @Test
+        @DisplayName("[TC-DND-001] TODAY 타입 드래그 앤 드롭")
+        void dragAndDrop_today() {
+            // given
+            Long userId = 1L;
+            Todo todo1 = mock(Todo.class);
+            Todo todo2 = mock(Todo.class);
+            when(todo1.getUserId()).thenReturn(userId);
+            when(todo2.getUserId()).thenReturn(userId);
+            when(todo1.getTodayStatus()).thenReturn(TodayStatus.INCOMPLETE);
+            when(todo2.getTodayStatus()).thenReturn(TodayStatus.INCOMPLETE);
+            when(todo1.getTodayOrder()).thenReturn(1);
+            when(todo2.getTodayOrder()).thenReturn(2);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(1L)).thenReturn(Optional.of(todo1));
+            when(todoRepository.findById(2L)).thenReturn(Optional.of(todo2));
+
+            TodoDragAndDropRequestDto requestDto = new TodoDragAndDropRequestDto(Type.TODAY, List.of(2L, 1L));
+
+            // when
+            todoService.dragAndDrop(userId, requestDto);
+
+            // then
+            verify(todoRepository).save(todo2);
+            verify(todoRepository).save(todo1);
+        }
+
+        @Test
+        @DisplayName("[TC-DND-002] BACKLOG 타입 드래그 앤 드롭")
+        void dragAndDrop_backlog() {
+            // given
+            Long userId = 1L;
+            Todo todo1 = mock(Todo.class);
+            Todo todo2 = mock(Todo.class);
+            when(todo1.getUserId()).thenReturn(userId);
+            when(todo2.getUserId()).thenReturn(userId);
+            when(todo1.getTodayStatus()).thenReturn(null);
+            when(todo2.getTodayStatus()).thenReturn(null);
+            when(todo1.getBacklogOrder()).thenReturn(1);
+            when(todo2.getBacklogOrder()).thenReturn(2);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(1L)).thenReturn(Optional.of(todo1));
+            when(todoRepository.findById(2L)).thenReturn(Optional.of(todo2));
+
+            TodoDragAndDropRequestDto requestDto = new TodoDragAndDropRequestDto(Type.BACKLOG, List.of(2L, 1L));
+
+            // when
+            todoService.dragAndDrop(userId, requestDto);
+
+            // then
+            verify(todoRepository).save(todo2);
+            verify(todoRepository).save(todo1);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-005] 할 일 상세 정보를 조회한다")
+    class GetTodoInfo {
+
+        @Test
+        @DisplayName("[TC-INFO-001] 카테고리와 이모지가 있는 할 일 조회")
+        void getTodoInfo_withCategoryAndEmoji() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            Long categoryId = 10L;
+            Long emojiId = 5L;
+            MobileType mobileType = MobileType.IOS;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+            when(todo.getCategoryId()).thenReturn(categoryId);
+            when(todo.getContent()).thenReturn("테스트 할 일");
+            when(todo.getTime()).thenReturn(LocalTime.of(10, 0));
+            when(todo.getDeadline()).thenReturn(LocalDate.now().plusDays(7));
+            when(todo.isBookmark()).thenReturn(false);
+            when(todo.isRepeat()).thenReturn(false);
+            when(todo.isRoutine()).thenReturn(false);
+
+            Category category = mock(Category.class);
+            when(category.getName()).thenReturn("운동");
+            when(category.getEmojiId()).thenReturn(emojiId);
+
+            Emoji emoji = mock(Emoji.class);
+            when(emoji.getImageUrl()).thenReturn("http://example.com/emoji.png");
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(emojiRepository.findById(emojiId)).thenReturn(Optional.of(emoji));
+            when(routineRepository.findAllByTodoId(todoId)).thenReturn(List.of());
+
+            // when
+            TodoDetailResponseDto response = todoService.getTodoInfo(userId, mobileType, todoId);
+
+            // then
+            assertThat(response).isNotNull();
+            verify(categoryRepository).findById(categoryId);
+            verify(emojiRepository).findById(emojiId);
+        }
+
+        @Test
+        @DisplayName("[TC-INFO-002] 카테고리가 없는 할 일 조회")
+        void getTodoInfo_withoutCategory() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            MobileType mobileType = MobileType.ANDROID;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+            when(todo.getCategoryId()).thenReturn(null);
+            when(todo.getContent()).thenReturn("테스트 할 일");
+            when(todo.getTime()).thenReturn(null);
+            when(todo.getDeadline()).thenReturn(null);
+            when(todo.isBookmark()).thenReturn(false);
+            when(todo.isRepeat()).thenReturn(false);
+            when(todo.isRoutine()).thenReturn(false);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(routineRepository.findAllByTodoId(todoId)).thenReturn(List.of());
+
+            // when
+            TodoDetailResponseDto response = todoService.getTodoInfo(userId, mobileType, todoId);
+
+            // then
+            assertThat(response).isNotNull();
+            verify(categoryRepository, never()).findById(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-006] 시간을 업데이트한다")
+    class UpdateTime {
+
+        @Test
+        @DisplayName("[TC-TIME-001] 시간 설정: 알람이 없으면 새로 생성")
+        void updateTime_createAlarm() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            LocalTime newTime = LocalTime.of(14, 30);
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(timeAlarmRepository.findByTodoId(todoId)).thenReturn(Optional.empty());
+
+            TimeUpdateRequestDto requestDto = new TimeUpdateRequestDto(newTime);
+
+            // when
+            todoService.updateTime(userId, todoId, requestDto);
+
+            // then
+            verify(timeAlarmRepository).save(any(TimeAlarm.class));
+            verify(todo).updateTime(newTime);
+        }
+
+        @Test
+        @DisplayName("[TC-TIME-002] 시간 설정: 기존 알람 업데이트")
+        void updateTime_updateExistingAlarm() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            LocalTime newTime = LocalTime.of(14, 30);
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            TimeAlarm existingAlarm = mock(TimeAlarm.class);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(timeAlarmRepository.findByTodoId(todoId)).thenReturn(Optional.of(existingAlarm));
+
+            TimeUpdateRequestDto requestDto = new TimeUpdateRequestDto(newTime);
+
+            // when
+            todoService.updateTime(userId, todoId, requestDto);
+
+            // then
+            verify(existingAlarm).updateNotified(false);
+            verify(timeAlarmRepository).save(existingAlarm);
+            verify(todo).updateTime(newTime);
+        }
+
+        @Test
+        @DisplayName("[TC-TIME-003] 시간 삭제: 기존 알람 삭제")
+        void updateTime_deleteAlarm() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            TimeAlarm existingAlarm = mock(TimeAlarm.class);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(timeAlarmRepository.findByTodoId(todoId)).thenReturn(Optional.of(existingAlarm));
+
+            TimeUpdateRequestDto requestDto = new TimeUpdateRequestDto(null);
+
+            // when
+            todoService.updateTime(userId, todoId, requestDto);
+
+            // then
+            verify(timeAlarmRepository).delete(existingAlarm);
+            verify(todo).updateTime(null);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-007] 마감기한을 업데이트한다")
+    class UpdateDeadline {
+
+        @Test
+        @DisplayName("[TC-DDL-001] 성공: 마감기한 설정")
+        void updateDeadline_success() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            LocalDate deadline = LocalDate.now().plusDays(7);
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            DeadlineUpdateRequestDto requestDto = new DeadlineUpdateRequestDto(deadline);
+
+            // when
+            todoService.updateDeadline(userId, todoId, requestDto);
+
+            // then
+            verify(todo).updateDeadline(deadline);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-008] 루틴을 관리한다")
+    class ManageRoutine {
+
+        @Test
+        @DisplayName("[TC-RTN-001] 루틴 생성")
+        void createRoutine_success() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            List<String> routineDays = List.of("월", "수", "금");
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            RoutineUpdateRequestDto requestDto = new RoutineUpdateRequestDto(routineDays);
+
+            // when
+            todoService.createRoutine(userId, todoId, requestDto);
+
+            // then
+            verify(todo).setRoutine(true);
+            verify(todo).setRepeat(false);
+            verify(routineRepository).deleteByTodoId(todoId);
+            verify(routineRepository).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("[TC-RTN-002] 루틴 삭제")
+        void deleteRoutine_success() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            // when
+            todoService.deleteRoutine(userId, todoId);
+
+            // then
+            verify(todo).setRoutine(false);
+            verify(routineRepository).deleteByTodoId(todoId);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-009] 내용을 업데이트한다")
+    class UpdateContent {
+
+        @Test
+        @DisplayName("[TC-CNT-001] 성공: 내용 수정")
+        void updateContent_success() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            String newContent = "수정된 할 일 내용";
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            ContentUpdateRequestDto requestDto = new ContentUpdateRequestDto(newContent);
+
+            // when
+            todoService.updateContent(userId, todoId, requestDto);
+
+            // then
+            verify(todo).updateContent(newContent);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-010] 완료 상태를 업데이트한다")
+    class UpdateIsCompleted {
+
+        @Test
+        @DisplayName("[TC-CMP-001] 미완료 -> 완료 변경")
+        void updateIsCompleted_incompleteToComplete() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+            when(todo.getId()).thenReturn(todoId);
+            when(todo.getTodayStatus()).thenReturn(TodayStatus.INCOMPLETE);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            // when
+            todoService.updateIsCompleted(userId, todoId);
+
+            // then
+            verify(todo).completeTodayTodo();
+            verify(completedDateTimeRepository).save(any(CompletedDateTime.class));
+        }
+
+        @Test
+        @DisplayName("[TC-CMP-002] 완료 -> 미완료 변경")
+        void updateIsCompleted_completeToIncomplete() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            LocalDate todayDate = LocalDate.now();
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+            when(todo.getId()).thenReturn(todoId);
+            when(todo.getTodayStatus()).thenReturn(TodayStatus.COMPLETED);
+            when(todo.getTodayDate()).thenReturn(todayDate);
+
+            CompletedDateTime completedDateTime = mock(CompletedDateTime.class);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(todoRepository.findMinTodayOrderByUserIdOrZero(userId)).thenReturn(1);
+            when(completedDateTimeRepository.findByTodoIdAndDate(todoId, todayDate))
+                    .thenReturn(Optional.of(completedDateTime));
+
+            // when
+            todoService.updateIsCompleted(userId, todoId);
+
+            // then
+            verify(todo).incompleteTodayTodo(1);
+            verify(completedDateTimeRepository).delete(completedDateTime);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-011] 카테고리를 업데이트한다")
+    class UpdateCategory {
+
+        @Test
+        @DisplayName("[TC-CAT-001] 성공: 카테고리 변경")
+        void updateCategory_success() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            Long newCategoryId = 20L;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            doNothing().when(categoryValidator).validateCategory(userId, newCategoryId);
+
+            TodoCategoryUpdateRequestDto requestDto = new TodoCategoryUpdateRequestDto(newCategoryId);
+
+            // when
+            todoService.updateCategory(userId, todoId, requestDto);
+
+            // then
+            verify(categoryValidator).validateCategory(userId, newCategoryId);
+            verify(todo).updateCategory(newCategoryId);
+        }
+
+        @Test
+        @DisplayName("[TC-CAT-002] 성공: 카테고리 해제 (null)")
+        void updateCategory_removeCategory() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            TodoCategoryUpdateRequestDto requestDto = new TodoCategoryUpdateRequestDto(null);
+
+            // when
+            todoService.updateCategory(userId, todoId, requestDto);
+
+            // then
+            verify(categoryValidator, never()).validateCategory(anyLong(), anyLong());
+            verify(todo).updateCategory(null);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-012] 반복 설정을 관리한다")
+    class ManageRepeat {
+
+        @Test
+        @DisplayName("[TC-RPT-001] 반복 토글")
+        void updateIsRepeat_toggle() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            // when
+            todoService.updateIsRepeat(userId, todoId);
+
+            // then
+            verify(todo).toggleRepeat();
+        }
+
+        @Test
+        @DisplayName("[TC-RPT-002] 일반 반복 생성")
+        void createIsRepeat_success() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            // when
+            todoService.createIsRepeat(userId, todoId);
+
+            // then
+            verify(todo).setRepeat(true);
+            verify(todo).setRoutine(false);
+            verify(routineRepository).deleteByTodoId(todoId);
+        }
+
+        @Test
+        @DisplayName("[TC-RPT-003] 일반 반복 삭제")
+        void deleteIsRepeat_success() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+
+            // when
+            todoService.deleteIsRepeat(userId, todoId);
+
+            // then
+            verify(todo).setRepeat(false);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-013] 히스토리 캘린더를 조회한다")
+    class GetHistoriesCalendar {
+
+        @Test
+        @DisplayName("[TC-CAL-001] 레거시 캘린더 조회")
+        void getLegacyHistoriesCalendar_success() {
+            // given
+            Long userId = 1L;
+            String year = "2025";
+            int month = 1;
+
+            List<LocalDateTime> historyDates = List.of(
+                    LocalDateTime.of(2025, 1, 5, 10, 0),
+                    LocalDateTime.of(2025, 1, 10, 14, 30)
+            );
+
+            when(completedDateTimeRepository.findHistoryExistingDates(userId, year, month))
+                    .thenReturn(historyDates);
+
+            // when
+            List<LocalDate> result = todoService.getLegacyHistoriesCalendar(userId, year, month);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).contains(LocalDate.of(2025, 1, 5), LocalDate.of(2025, 1, 10));
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-015] 히스토리를 조회한다")
+    class GetHistories {
+
+        @Test
+        @DisplayName("[TC-HST-001] 과거 날짜 히스토리 조회")
+        void getHistories_pastDate() {
+            // given
+            Long userId = 1L;
+            LocalDate pastDate = LocalDate.now().minusDays(7);
+            int page = 0;
+            int size = 10;
+
+            Todo todo = mock(Todo.class);
+            Page<Todo> todoPage = new PageImpl<>(List.of(todo));
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findHistories(eq(userId), eq(pastDate), any(PageRequest.class)))
+                    .thenReturn(todoPage);
+
+            // when
+            PaginatedHistoryResponseDto result = todoService.getHistories(userId, pastDate, page, size);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(todoRepository).findHistories(eq(userId), eq(pastDate), any(PageRequest.class));
+        }
+
+        @Test
+        @DisplayName("[TC-HST-002] 오늘 날짜 히스토리 조회")
+        void getHistories_today() {
+            // given
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+            int page = 0;
+            int size = 10;
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findIncompleteTodays(userId, Type.TODAY, today, TodayStatus.INCOMPLETE))
+                    .thenReturn(List.of());
+            when(todoRepository.findCompletedTodays(userId, today))
+                    .thenReturn(List.of());
+
+            // when
+            PaginatedHistoryResponseDto result = todoService.getHistories(userId, today, page, size);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(todoRepository).findIncompleteTodays(userId, Type.TODAY, today, TodayStatus.INCOMPLETE);
+            verify(todoRepository).findCompletedTodays(userId, today);
+        }
+
+        @Test
+        @DisplayName("[TC-HST-003] 미래 날짜 히스토리 조회 (마감기한 + 루틴)")
+        void getHistories_futureDate() {
+            // given
+            Long userId = 1L;
+            LocalDate futureDate = LocalDate.now().plusDays(7);
+            int page = 0;
+            int size = 10;
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findTodosByDeadLine(userId, futureDate))
+                    .thenReturn(List.of());
+            when(todoRepository.findRoutineTodosByDay(eq(userId), anyString()))
+                    .thenReturn(List.of());
+
+            // when
+            PaginatedHistoryResponseDto result = todoService.getHistories(userId, futureDate, page, size);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(todoRepository).findTodosByDeadLine(userId, futureDate);
+            verify(todoRepository).findRoutineTodosByDay(eq(userId), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-016] 마감기한/루틴 기반 오늘로 이동한다")
+    class ProcessUpdateDeadlineTodos {
+
+        @Test
+        @DisplayName("[TC-DL-001] 마감기한이 오늘인 할 일이 오늘로 이동한다")
+        void processUpdateDeadlineTodos_deadlineMatched() {
+            // given
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+
+            Todo deadlineTodo = mock(Todo.class);
+
+            when(todoRepository.findMaxTodayOrderByUserIdOrZero(userId)).thenReturn(5);
+            when(todoRepository.findTodosByDeadLine(userId, today))
+                    .thenReturn(List.of(deadlineTodo));
+            when(todoRepository.findRoutineTodosByDay(eq(userId), anyString()))
+                    .thenReturn(List.of());
+
+            // when
+            todoService.processUpdateDeadlineTodos(today, List.of(userId));
+
+            // then
+            verify(deadlineTodo).changeToToday(5);
+        }
+
+        @Test
+        @DisplayName("[TC-DL-002] 오늘 요일 루틴 할 일이 오늘로 이동한다")
+        void processUpdateDeadlineTodos_routineMatched() {
+            // given
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+
+            Todo routineTodo = mock(Todo.class);
+
+            when(todoRepository.findMaxTodayOrderByUserIdOrZero(userId)).thenReturn(5);
+            when(todoRepository.findTodosByDeadLine(userId, today))
+                    .thenReturn(List.of());
+            when(todoRepository.findRoutineTodosByDay(eq(userId), anyString()))
+                    .thenReturn(List.of(routineTodo));
+
+            // when
+            todoService.processUpdateDeadlineTodos(today, List.of(userId));
+
+            // then
+            verify(routineTodo).changeToToday(5);
+        }
+
+        @Test
+        @DisplayName("[TC-DL-003] 마감기한과 루틴 모두 매칭되면 순서대로 이동한다")
+        void processUpdateDeadlineTodos_bothMatched() {
+            // given
+            Long userId = 1L;
+            LocalDate today = LocalDate.now();
+
+            Todo deadlineTodo = mock(Todo.class);
+            Todo routineTodo = mock(Todo.class);
+
+            when(todoRepository.findMaxTodayOrderByUserIdOrZero(userId)).thenReturn(5);
+            when(todoRepository.findTodosByDeadLine(userId, today))
+                    .thenReturn(List.of(deadlineTodo));
+            when(todoRepository.findRoutineTodosByDay(eq(userId), anyString()))
+                    .thenReturn(List.of(routineTodo));
+
+            // when
+            todoService.processUpdateDeadlineTodos(today, List.of(userId));
+
+            // then
+            verify(deadlineTodo).changeToToday(5);
+            verify(routineTodo).changeToToday(6);
+        }
+    }
+
+    private Todo createTodo(Long userId, Long todoId, Type type) {
+        return Todo.builder()
+                .userId(userId)
+                .content("테스트 할 일")
+                .type(type)
+                .build();
+    }
 }

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -102,7 +102,7 @@ class TodoServiceTest extends ServiceTestConfig {
             todoService.deleteTodoById(userId, todoId);
 
             // then
-            verify(todo).softDelete();
+            verify(todoRepository).softDeleteById(todoId);
         }
 
         @Test

--- a/src/test/java/server/poptato/todo/application/TodoTodayServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoTodayServiceTest.java
@@ -1,20 +1,44 @@
 package server.poptato.todo.application;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.mockStatic;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+
 import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.infra.firebase.application.FcmNotificationBatchService;
+import server.poptato.todo.api.request.EventCreateRequestDto;
 import server.poptato.todo.api.request.TodayTodoCreateRequestDto;
+import server.poptato.todo.application.response.TodayListResponseDto;
 import server.poptato.todo.application.response.TodayTodoCreateResponseDto;
 import server.poptato.todo.domain.entity.Todo;
+import server.poptato.todo.domain.repository.RoutineRepository;
 import server.poptato.todo.domain.repository.TodoRepository;
+import server.poptato.todo.domain.value.TodayStatus;
+import server.poptato.todo.domain.value.Type;
+import server.poptato.user.domain.repository.UserRepository;
+import server.poptato.user.domain.value.MobileType;
 import server.poptato.user.validator.UserValidator;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
 
 class TodoTodayServiceTest extends ServiceTestConfig {
 
@@ -22,7 +46,16 @@ class TodoTodayServiceTest extends ServiceTestConfig {
     private TodoRepository todoRepository;
 
     @Mock
+    private RoutineRepository routineRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private UserValidator userValidator;
+
+    @Mock
+    private FcmNotificationBatchService fcmNotificationBatchService;
 
     @InjectMocks
     private TodoTodayService todoTodayService;
@@ -78,5 +111,166 @@ class TodoTodayServiceTest extends ServiceTestConfig {
 
         assertThat(response).isNotNull();
         assertThat(response.todoId()).isEqualTo(100L);
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-TODAY-002] 오늘의 할 일 목록을 조회한다")
+    class GetTodayList {
+
+        @Test
+        @DisplayName("[TC-LIST-001] 오늘의 할 일 목록 조회 - 빈 목록")
+        void getTodayList_emptyList() {
+            // given
+            Long userId = 1L;
+            MobileType mobileType = MobileType.IOS;
+            int page = 0;
+            int size = 10;
+            LocalDate todayDate = LocalDate.now();
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findIncompleteTodaysWithCategory(userId, Type.TODAY, todayDate, TodayStatus.INCOMPLETE))
+                    .thenReturn(Collections.emptyList());
+            when(todoRepository.findCompletedTodaysWithCategory(userId, todayDate))
+                    .thenReturn(Collections.emptyList());
+
+            // when
+            TodayListResponseDto response = todoTodayService.getTodayList(userId, mobileType, page, size, todayDate);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.todays()).isEmpty();
+            assertThat(response.totalPageCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("[TC-LIST-002] 오늘의 할 일 목록 조회 - 할 일이 있는 경우")
+        void getTodayList_withTodos() {
+            // given
+            Long userId = 1L;
+            MobileType mobileType = MobileType.IOS;
+            int page = 0;
+            int size = 10;
+            LocalDate todayDate = LocalDate.now();
+
+            Todo incompleteTodo = mock(Todo.class);
+            when(incompleteTodo.getId()).thenReturn(1L);
+            when(incompleteTodo.getContent()).thenReturn("미완료 할 일");
+            when(incompleteTodo.getTodayStatus()).thenReturn(TodayStatus.INCOMPLETE);
+            when(incompleteTodo.isBookmark()).thenReturn(false);
+            when(incompleteTodo.isRepeat()).thenReturn(false);
+            when(incompleteTodo.isRoutine()).thenReturn(false);
+            when(incompleteTodo.getDeadline()).thenReturn(null);
+            when(incompleteTodo.getTime()).thenReturn(null);
+
+            Todo completedTodo = mock(Todo.class);
+            when(completedTodo.getId()).thenReturn(2L);
+            when(completedTodo.getContent()).thenReturn("완료된 할 일");
+            when(completedTodo.getTodayStatus()).thenReturn(TodayStatus.COMPLETED);
+            when(completedTodo.isBookmark()).thenReturn(false);
+            when(completedTodo.isRepeat()).thenReturn(false);
+            when(completedTodo.isRoutine()).thenReturn(false);
+            when(completedTodo.getDeadline()).thenReturn(null);
+            when(completedTodo.getTime()).thenReturn(null);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findIncompleteTodaysWithCategory(userId, Type.TODAY, todayDate, TodayStatus.INCOMPLETE))
+                    .thenReturn(List.of(incompleteTodo));
+            when(todoRepository.findCompletedTodaysWithCategory(userId, todayDate))
+                    .thenReturn(List.of(completedTodo));
+            when(routineRepository.findAllByTodoId(anyLong())).thenReturn(Collections.emptyList());
+
+            // when
+            TodayListResponseDto response = todoTodayService.getTodayList(userId, mobileType, page, size, todayDate);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.todays()).hasSize(2);
+            assertThat(response.totalPageCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("[TC-LIST-003] 오늘의 할 일 목록 조회 - 페이지 범위 초과")
+        void getTodayList_pageOutOfRange() {
+            // given
+            Long userId = 1L;
+            MobileType mobileType = MobileType.ANDROID;
+            int page = 10;
+            int size = 10;
+            LocalDate todayDate = LocalDate.now();
+
+            Todo todo = Todo.createTodayTodo(userId, "테스트", null, false, 1);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findIncompleteTodaysWithCategory(userId, Type.TODAY, todayDate, TodayStatus.INCOMPLETE))
+                    .thenReturn(List.of(todo));
+            when(todoRepository.findCompletedTodaysWithCategory(userId, todayDate))
+                    .thenReturn(Collections.emptyList());
+
+            // when
+            TodayListResponseDto response = todoTodayService.getTodayList(userId, mobileType, page, size, todayDate);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.todays()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-SVC-TODO-TODAY-003] 이벤트를 생성하고 할 일을 배포한다")
+    class CreateEventAndTodosIfNeeded {
+
+        @Test
+        @DisplayName("[TC-EVENT-001] 이벤트 생성 - Today Todo 생성하지 않음")
+        void createEvent_withoutTodayTodo() {
+            // given
+            EventCreateRequestDto request = new EventCreateRequestDto(
+                    "이벤트 알림",
+                    "이벤트 내용입니다",
+                    false,
+                    false,
+                    null,
+                    null
+            );
+
+            doNothing().when(fcmNotificationBatchService).sendEventNotifications(any(), any());
+
+            // when
+            todoTodayService.createEventAndTodosIfNeeded(request);
+
+            // then
+            verify(fcmNotificationBatchService).sendEventNotifications("이벤트 알림", "이벤트 내용입니다");
+            verify(userRepository, never()).findAllUserIds();
+            verify(todoRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("[TC-EVENT-002] 이벤트 생성 - Today Todo도 함께 생성")
+        void createEvent_withTodayTodo() {
+            // given
+            EventCreateRequestDto request = new EventCreateRequestDto(
+                    "이벤트 알림",
+                    "이벤트 내용입니다",
+                    true,
+                    true,
+                    "오늘의 할 일 내용",
+                    LocalTime.of(14, 0)
+            );
+
+            List<Long> userIds = List.of(1L, 2L, 3L);
+            Map<Long, Integer> maxOrders = Map.of(1L, 5, 2L, 3, 3L, 10);
+
+            doNothing().when(fcmNotificationBatchService).sendEventNotifications(any(), any());
+            when(userRepository.findAllUserIds()).thenReturn(userIds);
+            when(todoRepository.findMaxTodayOrdersByUserIdsOrZero(userIds)).thenReturn(maxOrders);
+
+            // when
+            todoTodayService.createEventAndTodosIfNeeded(request);
+
+            // then
+            verify(fcmNotificationBatchService).sendEventNotifications("이벤트 알림", "이벤트 내용입니다");
+            verify(userRepository).findAllUserIds();
+            verify(todoRepository).findMaxTodayOrdersByUserIdsOrZero(userIds);
+            verify(todoRepository).saveAll(anyList());
+        }
     }
 }

--- a/src/test/java/server/poptato/todo/domain/entity/TodoTest.java
+++ b/src/test/java/server/poptato/todo/domain/entity/TodoTest.java
@@ -406,23 +406,4 @@ class TodoTest extends ServiceTestConfig {
             assertThat(todo.isRoutine()).isFalse();
         }
     }
-
-    @Nested
-    @DisplayName("[SCN-TODO-012] Soft Delete")
-    class SoftDeleteTest {
-
-        @Test
-        @DisplayName("[TC-SD-001] softDelete 호출 시 isDeleted가 true로 변경된다")
-        void softDelete_setsIsDeletedToTrue() {
-            // given
-            Todo todo = Todo.createBacklog(1L, "테스트 할 일", 1);
-            assertThat(todo.isDeleted()).isFalse();
-
-            // when
-            todo.softDelete();
-
-            // then
-            assertThat(todo.isDeleted()).isTrue();
-        }
-    }
 }

--- a/src/test/java/server/poptato/todo/domain/entity/TodoTest.java
+++ b/src/test/java/server/poptato/todo/domain/entity/TodoTest.java
@@ -406,4 +406,23 @@ class TodoTest extends ServiceTestConfig {
             assertThat(todo.isRoutine()).isFalse();
         }
     }
+
+    @Nested
+    @DisplayName("[SCN-TODO-012] Soft Delete")
+    class SoftDeleteTest {
+
+        @Test
+        @DisplayName("[TC-SD-001] softDelete 호출 시 isDeleted가 true로 변경된다")
+        void softDelete_setsIsDeletedToTrue() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트 할 일", 1);
+            assertThat(todo.isDeleted()).isFalse();
+
+            // when
+            todo.softDelete();
+
+            // then
+            assertThat(todo.isDeleted()).isTrue();
+        }
+    }
 }

--- a/src/test/java/server/poptato/todo/domain/entity/TodoTest.java
+++ b/src/test/java/server/poptato/todo/domain/entity/TodoTest.java
@@ -1,45 +1,409 @@
 package server.poptato.todo.domain.entity;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import server.poptato.configuration.ServiceTestConfig;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
 
-class TodoTest {
+class TodoTest extends ServiceTestConfig {
 
-    @Test
-    @DisplayName("[TC-ENTITY-001] softDelete 호출 시 isDeleted가 true로 변경된다")
-    void softDelete_setsIsDeletedTrue() {
-        // given
-        Todo todo = Todo.builder()
-                .userId(1L)
-                .type(Type.BACKLOG)
-                .content("test")
-                .todayStatus(TodayStatus.INCOMPLETE)
-                .build();
+    @Nested
+    @DisplayName("[SCN-ENT-TODO-001] Todo 생성 팩토리 메서드")
+    class CreateTodo {
 
-        // when
-        todo.softDelete();
+        @Test
+        @DisplayName("[TC-CRT-001] createBacklog: 기본 백로그 생성")
+        void createBacklog_success() {
+            // given
+            Long userId = 1L;
+            String content = "테스트 할 일";
+            Integer backlogOrder = 5;
 
-        // then
-        assertThat(todo.isDeleted()).isTrue();
+            // when
+            Todo todo = Todo.createBacklog(userId, content, backlogOrder);
+
+            // then
+            assertThat(todo.getUserId()).isEqualTo(userId);
+            assertThat(todo.getContent()).isEqualTo(content);
+            assertThat(todo.getBacklogOrder()).isEqualTo(backlogOrder);
+            assertThat(todo.getType()).isEqualTo(Type.BACKLOG);
+            assertThat(todo.isBookmark()).isFalse();
+        }
+
+        @Test
+        @DisplayName("[TC-CRT-002] createBookmarkBacklog: 북마크된 백로그 생성")
+        void createBookmarkBacklog_success() {
+            // given
+            Long userId = 1L;
+            String content = "중요한 할 일";
+            Integer backlogOrder = 3;
+
+            // when
+            Todo todo = Todo.createBookmarkBacklog(userId, content, backlogOrder);
+
+            // then
+            assertThat(todo.getUserId()).isEqualTo(userId);
+            assertThat(todo.getContent()).isEqualTo(content);
+            assertThat(todo.getBacklogOrder()).isEqualTo(backlogOrder);
+            assertThat(todo.getType()).isEqualTo(Type.BACKLOG);
+            assertThat(todo.isBookmark()).isTrue();
+        }
+
+        @Test
+        @DisplayName("[TC-CRT-003] createCategoryBacklog: 카테고리가 있는 백로그 생성")
+        void createCategoryBacklog_success() {
+            // given
+            Long userId = 1L;
+            Long categoryId = 10L;
+            String content = "카테고리 할 일";
+            Integer backlogOrder = 2;
+
+            // when
+            Todo todo = Todo.createCategoryBacklog(userId, categoryId, content, backlogOrder);
+
+            // then
+            assertThat(todo.getUserId()).isEqualTo(userId);
+            assertThat(todo.getCategoryId()).isEqualTo(categoryId);
+            assertThat(todo.getContent()).isEqualTo(content);
+            assertThat(todo.getBacklogOrder()).isEqualTo(backlogOrder);
+            assertThat(todo.getType()).isEqualTo(Type.BACKLOG);
+        }
+
+        @Test
+        @DisplayName("[TC-CRT-004] createYesterdayBacklog: 어제 할 일 백로그 생성")
+        void createYesterdayBacklog_success() {
+            // given
+            Long userId = 1L;
+            String content = "어제 할 일";
+            Integer backlogOrder = 1;
+
+            // when
+            Todo todo = Todo.createYesterdayBacklog(userId, content, backlogOrder);
+
+            // then
+            assertThat(todo.getUserId()).isEqualTo(userId);
+            assertThat(todo.getContent()).isEqualTo(content);
+            assertThat(todo.getBacklogOrder()).isEqualTo(backlogOrder);
+            assertThat(todo.getType()).isEqualTo(Type.YESTERDAY);
+            assertThat(todo.getTodayDate()).isEqualTo(LocalDate.now().minusDays(1));
+            assertThat(todo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);
+        }
+
+        @Test
+        @DisplayName("[TC-CRT-005] createTodayTodo: 오늘 할 일 생성")
+        void createTodayTodo_success() {
+            // given
+            Long userId = 1L;
+            String content = "오늘 할 일";
+            LocalTime time = LocalTime.of(14, 30);
+            boolean isBookmark = true;
+            Integer todayOrder = 10;
+
+            // when
+            Todo todo = Todo.createTodayTodo(userId, content, time, isBookmark, todayOrder);
+
+            // then
+            assertThat(todo.getUserId()).isEqualTo(userId);
+            assertThat(todo.getContent()).isEqualTo(content);
+            assertThat(todo.getTime()).isEqualTo(time);
+            assertThat(todo.isBookmark()).isEqualTo(isBookmark);
+            assertThat(todo.isEvent()).isTrue();
+            assertThat(todo.getType()).isEqualTo(Type.TODAY);
+            assertThat(todo.getTodayDate()).isEqualTo(LocalDate.now());
+            assertThat(todo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);
+            assertThat(todo.getTodayOrder()).isEqualTo(todayOrder);
+        }
     }
 
-    @Test
-    @DisplayName("[TC-ENTITY-002] isDeleted 기본값은 false이다")
-    void isDeleted_defaultIsFalse() {
-        // given
-        Todo todo = Todo.builder()
-                .userId(1L)
-                .type(Type.BACKLOG)
-                .content("test")
-                .todayStatus(TodayStatus.INCOMPLETE)
-                .build();
+    @Nested
+    @DisplayName("[SCN-ENT-TODO-002] 상태 변경 메서드")
+    class StateChange {
 
-        // then
-        assertThat(todo.isDeleted()).isFalse();
+        @Test
+        @DisplayName("[TC-CHG-001] changeToToday: 백로그에서 오늘로 변경")
+        void changeToToday_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 5);
+            Integer maxTodayOrder = 10;
+
+            // when
+            todo.changeToToday(maxTodayOrder);
+
+            // then
+            assertThat(todo.getType()).isEqualTo(Type.TODAY);
+            assertThat(todo.getBacklogOrder()).isNull();
+            assertThat(todo.getTodayOrder()).isEqualTo(maxTodayOrder + 1);
+            assertThat(todo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);
+            assertThat(todo.getTodayDate()).isEqualTo(LocalDate.now());
+        }
+
+        @Test
+        @DisplayName("[TC-CHG-002] changeToBacklog: 오늘에서 백로그로 변경")
+        void changeToBacklog_success() {
+            // given
+            Todo todo = Todo.createTodayTodo(1L, "테스트", null, false, 5);
+            Integer maxBacklogOrder = 20;
+
+            // when
+            todo.changeToBacklog(maxBacklogOrder);
+
+            // then
+            assertThat(todo.getType()).isEqualTo(Type.BACKLOG);
+            assertThat(todo.getBacklogOrder()).isEqualTo(maxBacklogOrder + 1);
+            assertThat(todo.getTodayOrder()).isNull();
+            assertThat(todo.getTodayStatus()).isNull();
+            assertThat(todo.getTodayDate()).isNull();
+        }
+
+        @Test
+        @DisplayName("[TC-CHG-003] toggleBookmark: 북마크 토글")
+        void toggleBookmark_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 1);
+            assertThat(todo.isBookmark()).isFalse();
+
+            // when
+            todo.toggleBookmark();
+
+            // then
+            assertThat(todo.isBookmark()).isTrue();
+
+            // when - 다시 토글
+            todo.toggleBookmark();
+
+            // then
+            assertThat(todo.isBookmark()).isFalse();
+        }
+
+        @Test
+        @DisplayName("[TC-CHG-004] completeTodayTodo: 오늘 할 일 완료")
+        void completeTodayTodo_success() {
+            // given
+            Todo todo = Todo.createTodayTodo(1L, "테스트", null, false, 5);
+            assertThat(todo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);
+
+            // when
+            todo.completeTodayTodo();
+
+            // then
+            assertThat(todo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
+            assertThat(todo.getTodayOrder()).isNull();
+        }
+
+        @Test
+        @DisplayName("[TC-CHG-005] incompleteTodayTodo: 오늘 할 일 미완료로 변경")
+        void incompleteTodayTodo_success() {
+            // given
+            Todo todo = Todo.createTodayTodo(1L, "테스트", null, false, 5);
+            todo.completeTodayTodo();
+            Integer minTodayOrder = 1;
+
+            // when
+            todo.incompleteTodayTodo(minTodayOrder);
+
+            // then
+            assertThat(todo.getTodayStatus()).isEqualTo(TodayStatus.INCOMPLETE);
+            assertThat(todo.getTodayOrder()).isEqualTo(minTodayOrder - 1);
+        }
+
+        @Test
+        @DisplayName("[TC-CHG-006] updateYesterdayToCompleted: 어제 할 일 완료로 변경")
+        void updateYesterdayToCompleted_success() {
+            // given
+            Todo todo = Todo.createYesterdayBacklog(1L, "어제 할 일", 3);
+
+            // when
+            todo.updateYesterdayToCompleted();
+
+            // then
+            assertThat(todo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
+            assertThat(todo.getBacklogOrder()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-ENT-TODO-003] 필드 업데이트 메서드")
+    class FieldUpdate {
+
+        @Test
+        @DisplayName("[TC-UPD-001] updateTime: 시간 업데이트")
+        void updateTime_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 1);
+            LocalTime newTime = LocalTime.of(15, 30);
+
+            // when
+            todo.updateTime(newTime);
+
+            // then
+            assertThat(todo.getTime()).isEqualTo(newTime);
+        }
+
+        @Test
+        @DisplayName("[TC-UPD-002] updateDeadline: 마감기한 업데이트")
+        void updateDeadline_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 1);
+            LocalDate newDeadline = LocalDate.now().plusDays(7);
+
+            // when
+            todo.updateDeadline(newDeadline);
+
+            // then
+            assertThat(todo.getDeadline()).isEqualTo(newDeadline);
+        }
+
+        @Test
+        @DisplayName("[TC-UPD-003] updateContent: 내용 업데이트")
+        void updateContent_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "기존 내용", 1);
+            String newContent = "수정된 내용";
+
+            // when
+            todo.updateContent(newContent);
+
+            // then
+            assertThat(todo.getContent()).isEqualTo(newContent);
+        }
+
+        @Test
+        @DisplayName("[TC-UPD-004] updateCategory: 카테고리 업데이트")
+        void updateCategory_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 1);
+            Long newCategoryId = 20L;
+
+            // when
+            todo.updateCategory(newCategoryId);
+
+            // then
+            assertThat(todo.getCategoryId()).isEqualTo(newCategoryId);
+        }
+
+        @Test
+        @DisplayName("[TC-UPD-005] updateTodayStatus: 오늘 상태 업데이트")
+        void updateTodayStatus_success() {
+            // given
+            Todo todo = Todo.createTodayTodo(1L, "테스트", null, false, 5);
+
+            // when
+            todo.updateTodayStatus(TodayStatus.COMPLETED);
+
+            // then
+            assertThat(todo.getTodayStatus()).isEqualTo(TodayStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("[TC-UPD-006] updateType: 타입 업데이트")
+        void updateType_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 1);
+
+            // when
+            todo.updateType(Type.TODAY);
+
+            // then
+            assertThat(todo.getType()).isEqualTo(Type.TODAY);
+        }
+
+        @Test
+        @DisplayName("[TC-UPD-007] updateTodayOrder: 오늘 순서 업데이트")
+        void updateTodayOrder_success() {
+            // given
+            Todo todo = Todo.createTodayTodo(1L, "테스트", null, false, 5);
+            Integer newOrder = 10;
+
+            // when
+            todo.updateTodayOrder(newOrder);
+
+            // then
+            assertThat(todo.getTodayOrder()).isEqualTo(newOrder);
+        }
+
+        @Test
+        @DisplayName("[TC-UPD-008] updateBacklogOrder: 백로그 순서 업데이트")
+        void updateBacklogOrder_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 5);
+            Integer newOrder = 15;
+
+            // when
+            todo.updateBacklogOrder(newOrder);
+
+            // then
+            assertThat(todo.getBacklogOrder()).isEqualTo(newOrder);
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-ENT-TODO-004] 반복 설정 메서드")
+    class RepeatSetting {
+
+        @Test
+        @DisplayName("[TC-RPT-001] toggleRepeat: 반복 토글")
+        void toggleRepeat_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 1);
+            assertThat(todo.isRepeat()).isFalse();
+
+            // when
+            todo.toggleRepeat();
+
+            // then
+            assertThat(todo.isRepeat()).isTrue();
+
+            // when - 다시 토글
+            todo.toggleRepeat();
+
+            // then
+            assertThat(todo.isRepeat()).isFalse();
+        }
+
+        @Test
+        @DisplayName("[TC-RPT-002] setRepeat: 반복 설정")
+        void setRepeat_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 1);
+
+            // when
+            todo.setRepeat(true);
+
+            // then
+            assertThat(todo.isRepeat()).isTrue();
+
+            // when
+            todo.setRepeat(false);
+
+            // then
+            assertThat(todo.isRepeat()).isFalse();
+        }
+
+        @Test
+        @DisplayName("[TC-RPT-003] setRoutine: 루틴 설정")
+        void setRoutine_success() {
+            // given
+            Todo todo = Todo.createBacklog(1L, "테스트", 1);
+
+            // when
+            todo.setRoutine(true);
+
+            // then
+            assertThat(todo.isRoutine()).isTrue();
+
+            // when
+            todo.setRoutine(false);
+
+            // then
+            assertThat(todo.isRoutine()).isFalse();
+        }
     }
 }

--- a/src/test/java/server/poptato/todo/domain/entity/TodoTest.java
+++ b/src/test/java/server/poptato/todo/domain/entity/TodoTest.java
@@ -1,0 +1,45 @@
+package server.poptato.todo.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import server.poptato.todo.domain.value.TodayStatus;
+import server.poptato.todo.domain.value.Type;
+
+class TodoTest {
+
+    @Test
+    @DisplayName("[TC-ENTITY-001] softDelete 호출 시 isDeleted가 true로 변경된다")
+    void softDelete_setsIsDeletedTrue() {
+        // given
+        Todo todo = Todo.builder()
+                .userId(1L)
+                .type(Type.BACKLOG)
+                .content("test")
+                .todayStatus(TodayStatus.INCOMPLETE)
+                .build();
+
+        // when
+        todo.softDelete();
+
+        // then
+        assertThat(todo.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("[TC-ENTITY-002] isDeleted 기본값은 false이다")
+    void isDeleted_defaultIsFalse() {
+        // given
+        Todo todo = Todo.builder()
+                .userId(1L)
+                .type(Type.BACKLOG)
+                .content("test")
+                .todayStatus(TodayStatus.INCOMPLETE)
+                .build();
+
+        // then
+        assertThat(todo.isDeleted()).isFalse();
+    }
+}

--- a/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
+++ b/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
@@ -37,9 +37,13 @@ public class JpaTodoRepositoryTest extends DatabaseTestConfig {
     }
 
     private Boolean getIsDeleted(Long id) {
-        return (Boolean) tem.getEntityManager().createNativeQuery(
+        Object result = tem.getEntityManager().createNativeQuery(
                 "SELECT is_deleted FROM todo WHERE id = :id"
         ).setParameter("id", id).getSingleResult();
+        if (result instanceof Boolean) {
+            return (Boolean) result;
+        }
+        return ((Number) result).intValue() == 1;
     }
 
     @Nested

--- a/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
+++ b/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
@@ -36,6 +36,12 @@ public class JpaTodoRepositoryTest extends DatabaseTestConfig {
         return todo;
     }
 
+    private Boolean getIsDeleted(Long id) {
+        return (Boolean) tem.getEntityManager().createNativeQuery(
+                "SELECT is_deleted FROM todo WHERE id = :id"
+        ).setParameter("id", id).getSingleResult();
+    }
+
     @Nested
     @DisplayName("[SCN-REP-TODO-001] Soft Delete 테스트")
     @TestMethodOrder(MethodOrderer.DisplayName.class)
@@ -57,14 +63,10 @@ public class JpaTodoRepositoryTest extends DatabaseTestConfig {
             tem.flush();
             tem.clear();
 
-            // then
-            Todo found1 = tem.find(Todo.class, todo1.getId());
-            Todo found2 = tem.find(Todo.class, todo2.getId());
-            Todo foundOther = tem.find(Todo.class, otherTodo.getId());
-
-            assertThat(found1.isDeleted()).isTrue();
-            assertThat(found2.isDeleted()).isTrue();
-            assertThat(foundOther.isDeleted()).isFalse();
+            // then - Native Query로 is_deleted 값 직접 확인 (@SQLRestriction 우회)
+            assertThat(getIsDeleted(todo1.getId())).isTrue();
+            assertThat(getIsDeleted(todo2.getId())).isTrue();
+            assertThat(getIsDeleted(otherTodo.getId())).isFalse();
         }
 
         @Test
@@ -84,14 +86,10 @@ public class JpaTodoRepositoryTest extends DatabaseTestConfig {
             tem.flush();
             tem.clear();
 
-            // then
-            Todo found1 = tem.find(Todo.class, todo1.getId());
-            Todo found2 = tem.find(Todo.class, todo2.getId());
-            Todo foundOther = tem.find(Todo.class, otherTodo.getId());
-
-            assertThat(found1.isDeleted()).isTrue();
-            assertThat(found2.isDeleted()).isTrue();
-            assertThat(foundOther.isDeleted()).isFalse();
+            // then - Native Query로 is_deleted 값 직접 확인 (@SQLRestriction 우회)
+            assertThat(getIsDeleted(todo1.getId())).isTrue();
+            assertThat(getIsDeleted(todo2.getId())).isTrue();
+            assertThat(getIsDeleted(otherTodo.getId())).isFalse();
         }
     }
 }

--- a/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
+++ b/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
@@ -1,0 +1,97 @@
+package server.poptato.todo.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import server.poptato.configuration.DatabaseTestConfig;
+import server.poptato.configuration.MySqlDataJpaTest;
+import server.poptato.todo.domain.entity.Todo;
+import server.poptato.todo.domain.value.TodayStatus;
+import server.poptato.todo.domain.value.Type;
+import server.poptato.todo.infra.repository.JpaTodoRepository;
+
+@MySqlDataJpaTest
+public class JpaTodoRepositoryTest extends DatabaseTestConfig {
+
+    @Autowired
+    private JpaTodoRepository jpaTodoRepository;
+
+    private Todo createTodo(Long userId, Long categoryId, String content) {
+        Todo todo = Todo.builder()
+                .userId(userId)
+                .categoryId(categoryId)
+                .type(Type.BACKLOG)
+                .content(content)
+                .todayStatus(TodayStatus.INCOMPLETE)
+                .build();
+        tem.persist(todo);
+        tem.flush();
+        tem.clear();
+        return todo;
+    }
+
+    @Nested
+    @DisplayName("[SCN-REP-TODO-001] Soft Delete 테스트")
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    class SoftDeleteTests {
+
+        @Test
+        @DisplayName("[TC-SOFT-DELETE-001] softDeleteByUserId 호출 시 해당 유저의 모든 Todo가 soft delete 된다")
+        void softDeleteByUserId_deletesAllUserTodos() {
+            // given
+            Long userId = 100L;
+            Long otherUserId = 200L;
+
+            Todo todo1 = createTodo(userId, null, "todo1");
+            Todo todo2 = createTodo(userId, null, "todo2");
+            Todo otherTodo = createTodo(otherUserId, null, "other");
+
+            // when
+            jpaTodoRepository.softDeleteByUserId(userId);
+            tem.flush();
+            tem.clear();
+
+            // then
+            Todo found1 = tem.find(Todo.class, todo1.getId());
+            Todo found2 = tem.find(Todo.class, todo2.getId());
+            Todo foundOther = tem.find(Todo.class, otherTodo.getId());
+
+            assertThat(found1.isDeleted()).isTrue();
+            assertThat(found2.isDeleted()).isTrue();
+            assertThat(foundOther.isDeleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("[TC-SOFT-DELETE-002] softDeleteByCategoryId 호출 시 해당 카테고리의 모든 Todo가 soft delete 된다")
+        void softDeleteByCategoryId_deletesAllCategoryTodos() {
+            // given
+            Long userId = 100L;
+            Long categoryId = 10L;
+            Long otherCategoryId = 20L;
+
+            Todo todo1 = createTodo(userId, categoryId, "todo1");
+            Todo todo2 = createTodo(userId, categoryId, "todo2");
+            Todo otherTodo = createTodo(userId, otherCategoryId, "other");
+
+            // when
+            jpaTodoRepository.softDeleteByCategoryId(categoryId);
+            tem.flush();
+            tem.clear();
+
+            // then
+            Todo found1 = tem.find(Todo.class, todo1.getId());
+            Todo found2 = tem.find(Todo.class, todo2.getId());
+            Todo foundOther = tem.find(Todo.class, otherTodo.getId());
+
+            assertThat(found1.isDeleted()).isTrue();
+            assertThat(found2.isDeleted()).isTrue();
+            assertThat(foundOther.isDeleted()).isFalse();
+        }
+    }
+}

--- a/src/test/java/server/poptato/todo/infra/TodoRepositoryImplTest.java
+++ b/src/test/java/server/poptato/todo/infra/TodoRepositoryImplTest.java
@@ -38,9 +38,13 @@ public class TodoRepositoryImplTest extends DatabaseTestConfig {
     }
 
     private Boolean getIsDeleted(Long id) {
-        return (Boolean) tem.getEntityManager().createNativeQuery(
+        Object result = tem.getEntityManager().createNativeQuery(
                 "SELECT is_deleted FROM todo WHERE id = :id"
         ).setParameter("id", id).getSingleResult();
+        if (result instanceof Boolean) {
+            return (Boolean) result;
+        }
+        return ((Number) result).intValue() == 1;
     }
 
     @Nested

--- a/src/test/java/server/poptato/todo/infra/TodoRepositoryImplTest.java
+++ b/src/test/java/server/poptato/todo/infra/TodoRepositoryImplTest.java
@@ -1,0 +1,95 @@
+package server.poptato.todo.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import server.poptato.configuration.DatabaseTestConfig;
+import server.poptato.configuration.MySqlDataJpaTest;
+import server.poptato.todo.domain.entity.Todo;
+import server.poptato.todo.domain.repository.TodoRepository;
+import server.poptato.todo.domain.value.TodayStatus;
+import server.poptato.todo.domain.value.Type;
+import server.poptato.todo.infra.repository.impl.TodoRepositoryImpl;
+
+@MySqlDataJpaTest
+@Import(TodoRepositoryImpl.class)
+public class TodoRepositoryImplTest extends DatabaseTestConfig {
+
+    @Autowired
+    private TodoRepository todoRepository;
+
+    private Todo createTodo(Long userId, Long categoryId, String content) {
+        Todo todo = Todo.builder()
+                .userId(userId)
+                .categoryId(categoryId)
+                .type(Type.BACKLOG)
+                .content(content)
+                .todayStatus(TodayStatus.INCOMPLETE)
+                .build();
+        tem.persist(todo);
+        tem.flush();
+        tem.clear();
+        return todo;
+    }
+
+    private Boolean getIsDeleted(Long id) {
+        return (Boolean) tem.getEntityManager().createNativeQuery(
+                "SELECT is_deleted FROM todo WHERE id = :id"
+        ).setParameter("id", id).getSingleResult();
+    }
+
+    @Nested
+    @DisplayName("[SCN-REP-IMPL-001] TodoRepositoryImpl Soft Delete 테스트")
+    class SoftDeleteTests {
+
+        @Test
+        @DisplayName("[TC-IMPL-001] softDeleteByUserId 호출 시 해당 유저의 모든 Todo가 soft delete 된다")
+        void softDeleteByUserId_deletesAllUserTodos() {
+            // given
+            Long userId = 1000L;
+            Long otherUserId = 2000L;
+
+            Todo todo1 = createTodo(userId, null, "todo1");
+            Todo todo2 = createTodo(userId, null, "todo2");
+            Todo otherTodo = createTodo(otherUserId, null, "other");
+
+            // when
+            todoRepository.softDeleteByUserId(userId);
+            tem.flush();
+            tem.clear();
+
+            // then
+            assertThat(getIsDeleted(todo1.getId())).isTrue();
+            assertThat(getIsDeleted(todo2.getId())).isTrue();
+            assertThat(getIsDeleted(otherTodo.getId())).isFalse();
+        }
+
+        @Test
+        @DisplayName("[TC-IMPL-002] softDeleteByCategoryId 호출 시 해당 카테고리의 모든 Todo가 soft delete 된다")
+        void softDeleteByCategoryId_deletesAllCategoryTodos() {
+            // given
+            Long userId = 1000L;
+            Long categoryId = 100L;
+            Long otherCategoryId = 200L;
+
+            Todo todo1 = createTodo(userId, categoryId, "todo1");
+            Todo todo2 = createTodo(userId, categoryId, "todo2");
+            Todo otherTodo = createTodo(userId, otherCategoryId, "other");
+
+            // when
+            todoRepository.softDeleteByCategoryId(categoryId);
+            tem.flush();
+            tem.clear();
+
+            // then
+            assertThat(getIsDeleted(todo1.getId())).isTrue();
+            assertThat(getIsDeleted(todo2.getId())).isTrue();
+            assertThat(getIsDeleted(otherTodo.getId())).isFalse();
+        }
+    }
+}

--- a/src/test/java/server/poptato/todo/infra/TodoRepositoryImplTest.java
+++ b/src/test/java/server/poptato/todo/infra/TodoRepositoryImplTest.java
@@ -95,5 +95,43 @@ public class TodoRepositoryImplTest extends DatabaseTestConfig {
             assertThat(getIsDeleted(todo2.getId())).isTrue();
             assertThat(getIsDeleted(otherTodo.getId())).isFalse();
         }
+
+        @Test
+        @DisplayName("[TC-IMPL-003] softDeleteById 호출 시 해당 Todo가 soft delete 된다")
+        void softDeleteById_deletesSingleTodo() {
+            // given
+            Long userId = 1000L;
+            Todo todo1 = createTodo(userId, null, "todo1");
+            Todo todo2 = createTodo(userId, null, "todo2");
+
+            // when
+            todoRepository.softDeleteById(todo1.getId());
+            tem.flush();
+            tem.clear();
+
+            // then
+            assertThat(getIsDeleted(todo1.getId())).isTrue();
+            assertThat(getIsDeleted(todo2.getId())).isFalse();
+        }
+
+        @Test
+        @DisplayName("[TC-IMPL-004] softDeleteByIds 호출 시 해당 Todo들이 모두 soft delete 된다")
+        void softDeleteByIds_deletesMultipleTodos() {
+            // given
+            Long userId = 1000L;
+            Todo todo1 = createTodo(userId, null, "todo1");
+            Todo todo2 = createTodo(userId, null, "todo2");
+            Todo todo3 = createTodo(userId, null, "todo3");
+
+            // when
+            todoRepository.softDeleteByIds(java.util.List.of(todo1.getId(), todo2.getId()));
+            tem.flush();
+            tem.clear();
+
+            // then
+            assertThat(getIsDeleted(todo1.getId())).isTrue();
+            assertThat(getIsDeleted(todo2.getId())).isTrue();
+            assertThat(getIsDeleted(todo3.getId())).isFalse();
+        }
     }
 }

--- a/src/test/java/server/poptato/user/application/UserServiceTest.java
+++ b/src/test/java/server/poptato/user/application/UserServiceTest.java
@@ -25,6 +25,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import server.poptato.auth.application.service.JwtService;
 import server.poptato.category.domain.repository.CategoryRepository;
 import server.poptato.configuration.ServiceTestConfig;
+import server.poptato.note.domain.repository.NoteRepository;
+import server.poptato.todo.domain.repository.TodoRepository;
 import server.poptato.global.exception.CustomException;
 import server.poptato.user.api.request.UserCommentRequestDTO;
 import server.poptato.user.api.request.UserDeleteRequestDTO;
@@ -71,6 +73,12 @@ class UserServiceTest extends ServiceTestConfig {
 
     @Mock
     MobileRepository mobileRepository;
+
+    @Mock
+    TodoRepository todoRepository;
+
+    @Mock
+    NoteRepository noteRepository;
 
     @InjectMocks
     private UserService userService;
@@ -143,8 +151,11 @@ class UserServiceTest extends ServiceTestConfig {
 
             // then
             then(deleteReasonRepository).should(times(reasons.size() + 1)).save(any());
-            then(userRepository).should().delete(found);
-            then(categoryRepository).should().deleteByUserId(userId);
+            assertThat(found.isDeleted()).isTrue();
+            then(todoRepository).should().softDeleteByUserId(userId);
+            then(categoryRepository).should().softDeleteByUserId(userId);
+            then(noteRepository).should().softDeleteByUserId(userId);
+            then(mobileRepository).should().deleteByUserId(userId);
             then(jwtService).should().revokeAllRefreshTokens(userId);
 
             ArgumentCaptor<DeleteUserEvent> captor = ArgumentCaptor.forClass(DeleteUserEvent.class);
@@ -212,49 +223,66 @@ class UserServiceTest extends ServiceTestConfig {
         void deleteUser_reasonCombination_savesExpectedTimes() {
             // given
             Long userId = 103L;
-            User found = user(userId, "tester");
-            given(userValidator.checkIsExistAndReturnUser(userId)).willReturn(found);
-            given(mobileRepository.findTopByUserIdOrderByModifyDateDesc(found.getId()))
-                    .willReturn(Optional.of(mobile(userId)));
 
             // (a) reasons만 존재
             {
-                reset(deleteReasonRepository, userRepository, categoryRepository, jwtService, eventPublisher);
+                User foundA = user(userId, "testerA");
+                reset(deleteReasonRepository, todoRepository, categoryRepository, noteRepository, mobileRepository, jwtService, eventPublisher, userValidator);
+                given(userValidator.checkIsExistAndReturnUser(userId)).willReturn(foundA);
+                given(mobileRepository.findTopByUserIdOrderByModifyDateDesc(foundA.getId()))
+                        .willReturn(Optional.of(mobile(userId)));
                 UserDeleteRequestDTO request = requestDTO(List.of(Reason.TOO_COMPLEX, Reason.NOT_USED_OFTEN), null);
 
                 userService.deleteUser(userId, request);
 
                 then(deleteReasonRepository).should(times(2)).save(any());
-                then(userRepository).should().delete(found);
-                then(categoryRepository).should().deleteByUserId(userId);
+                assertThat(foundA.isDeleted()).isTrue();
+                then(todoRepository).should().softDeleteByUserId(userId);
+                then(categoryRepository).should().softDeleteByUserId(userId);
+                then(noteRepository).should().softDeleteByUserId(userId);
+                then(mobileRepository).should().deleteByUserId(userId);
                 then(jwtService).should().revokeAllRefreshTokens(userId);
                 then(eventPublisher).should().publishEvent(any(DeleteUserEvent.class));
             }
 
             // (b) userInputReason만 존재(공백 아님)
             {
-                reset(deleteReasonRepository, userRepository, categoryRepository, jwtService, eventPublisher);
+                User foundB = user(userId, "testerB");
+                reset(deleteReasonRepository, todoRepository, categoryRepository, noteRepository, mobileRepository, jwtService, eventPublisher, userValidator);
+                given(userValidator.checkIsExistAndReturnUser(userId)).willReturn(foundB);
+                given(mobileRepository.findTopByUserIdOrderByModifyDateDesc(foundB.getId()))
+                        .willReturn(Optional.of(mobile(userId)));
                 UserDeleteRequestDTO request = requestDTO(List.of(), "custom reason");
 
                 userService.deleteUser(userId, request);
 
                 then(deleteReasonRepository).should(times(1)).save(any());
-                then(userRepository).should().delete(found);
-                then(categoryRepository).should().deleteByUserId(userId);
+                assertThat(foundB.isDeleted()).isTrue();
+                then(todoRepository).should().softDeleteByUserId(userId);
+                then(categoryRepository).should().softDeleteByUserId(userId);
+                then(noteRepository).should().softDeleteByUserId(userId);
+                then(mobileRepository).should().deleteByUserId(userId);
                 then(jwtService).should().revokeAllRefreshTokens(userId);
                 then(eventPublisher).should().publishEvent(any(DeleteUserEvent.class));
             }
 
             // (c) 둘 다 없음 또는 blank
             {
-                reset(deleteReasonRepository, userRepository, categoryRepository, jwtService, eventPublisher);
+                User foundC = user(userId, "testerC");
+                reset(deleteReasonRepository, todoRepository, categoryRepository, noteRepository, mobileRepository, jwtService, eventPublisher, userValidator);
+                given(userValidator.checkIsExistAndReturnUser(userId)).willReturn(foundC);
+                given(mobileRepository.findTopByUserIdOrderByModifyDateDesc(foundC.getId()))
+                        .willReturn(Optional.of(mobile(userId)));
                 UserDeleteRequestDTO request = requestDTO(List.of(), "   ");
 
                 userService.deleteUser(userId, request);
 
                 then(deleteReasonRepository).shouldHaveNoInteractions();
-                then(userRepository).should().delete(found);
-                then(categoryRepository).should().deleteByUserId(userId);
+                assertThat(foundC.isDeleted()).isTrue();
+                then(todoRepository).should().softDeleteByUserId(userId);
+                then(categoryRepository).should().softDeleteByUserId(userId);
+                then(noteRepository).should().softDeleteByUserId(userId);
+                then(mobileRepository).should().deleteByUserId(userId);
                 then(jwtService).should().revokeAllRefreshTokens(userId);
                 then(eventPublisher).should().publishEvent(any(DeleteUserEvent.class));
             }

--- a/src/test/java/server/poptato/user/application/UserServiceTest.java
+++ b/src/test/java/server/poptato/user/application/UserServiceTest.java
@@ -151,7 +151,7 @@ class UserServiceTest extends ServiceTestConfig {
 
             // then
             then(deleteReasonRepository).should(times(reasons.size() + 1)).save(any());
-            assertThat(found.isDeleted()).isTrue();
+            then(userRepository).should().softDeleteById(userId);
             then(todoRepository).should().softDeleteByUserId(userId);
             then(categoryRepository).should().softDeleteByUserId(userId);
             then(noteRepository).should().softDeleteByUserId(userId);
@@ -236,7 +236,7 @@ class UserServiceTest extends ServiceTestConfig {
                 userService.deleteUser(userId, request);
 
                 then(deleteReasonRepository).should(times(2)).save(any());
-                assertThat(foundA.isDeleted()).isTrue();
+                then(userRepository).should().softDeleteById(userId);
                 then(todoRepository).should().softDeleteByUserId(userId);
                 then(categoryRepository).should().softDeleteByUserId(userId);
                 then(noteRepository).should().softDeleteByUserId(userId);
@@ -248,7 +248,7 @@ class UserServiceTest extends ServiceTestConfig {
             // (b) userInputReason만 존재(공백 아님)
             {
                 User foundB = user(userId, "testerB");
-                reset(deleteReasonRepository, todoRepository, categoryRepository, noteRepository, mobileRepository, jwtService, eventPublisher, userValidator);
+                reset(deleteReasonRepository, todoRepository, categoryRepository, noteRepository, mobileRepository, jwtService, eventPublisher, userValidator, userRepository);
                 given(userValidator.checkIsExistAndReturnUser(userId)).willReturn(foundB);
                 given(mobileRepository.findTopByUserIdOrderByModifyDateDesc(foundB.getId()))
                         .willReturn(Optional.of(mobile(userId)));
@@ -257,7 +257,7 @@ class UserServiceTest extends ServiceTestConfig {
                 userService.deleteUser(userId, request);
 
                 then(deleteReasonRepository).should(times(1)).save(any());
-                assertThat(foundB.isDeleted()).isTrue();
+                then(userRepository).should().softDeleteById(userId);
                 then(todoRepository).should().softDeleteByUserId(userId);
                 then(categoryRepository).should().softDeleteByUserId(userId);
                 then(noteRepository).should().softDeleteByUserId(userId);
@@ -269,7 +269,7 @@ class UserServiceTest extends ServiceTestConfig {
             // (c) 둘 다 없음 또는 blank
             {
                 User foundC = user(userId, "testerC");
-                reset(deleteReasonRepository, todoRepository, categoryRepository, noteRepository, mobileRepository, jwtService, eventPublisher, userValidator);
+                reset(deleteReasonRepository, todoRepository, categoryRepository, noteRepository, mobileRepository, jwtService, eventPublisher, userValidator, userRepository);
                 given(userValidator.checkIsExistAndReturnUser(userId)).willReturn(foundC);
                 given(mobileRepository.findTopByUserIdOrderByModifyDateDesc(foundC.getId()))
                         .willReturn(Optional.of(mobile(userId)));
@@ -278,7 +278,7 @@ class UserServiceTest extends ServiceTestConfig {
                 userService.deleteUser(userId, request);
 
                 then(deleteReasonRepository).shouldHaveNoInteractions();
-                assertThat(foundC.isDeleted()).isTrue();
+                then(userRepository).should().softDeleteById(userId);
                 then(todoRepository).should().softDeleteByUserId(userId);
                 then(categoryRepository).should().softDeleteByUserId(userId);
                 then(noteRepository).should().softDeleteByUserId(userId);

--- a/src/test/java/server/poptato/user/domain/entity/UserTest.java
+++ b/src/test/java/server/poptato/user/domain/entity/UserTest.java
@@ -1,0 +1,49 @@
+package server.poptato.user.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import server.poptato.user.domain.value.SocialType;
+
+class UserTest {
+
+    @Test
+    @DisplayName("[TC-ENTITY-001] softDelete 호출 시 isDeleted가 true로 변경되고 socialId가 DELETED_ 접두사로 변경된다")
+    void softDelete_setsIsDeletedTrueAndChangesSocialId() {
+        // given
+        String originalSocialId = "kakao_12345";
+        User user = User.builder()
+                .socialType(SocialType.KAKAO)
+                .socialId(originalSocialId)
+                .name("test")
+                .email("test@test.com")
+                .isPushAlarm(true)
+                .build();
+
+        // when
+        user.softDelete();
+
+        // then
+        assertThat(user.isDeleted()).isTrue();
+        assertThat(user.getSocialId()).startsWith("DELETED_");
+        assertThat(user.getSocialId()).endsWith("_" + originalSocialId);
+    }
+
+    @Test
+    @DisplayName("[TC-ENTITY-002] isDeleted 기본값은 false이다")
+    void isDeleted_defaultIsFalse() {
+        // given
+        User user = User.builder()
+                .socialType(SocialType.KAKAO)
+                .socialId("kakao_12345")
+                .name("test")
+                .email("test@test.com")
+                .isPushAlarm(true)
+                .build();
+
+        // then
+        assertThat(user.isDeleted()).isFalse();
+    }
+}

--- a/src/test/java/server/poptato/user/domain/entity/UserTest.java
+++ b/src/test/java/server/poptato/user/domain/entity/UserTest.java
@@ -10,29 +10,7 @@ import server.poptato.user.domain.value.SocialType;
 class UserTest {
 
     @Test
-    @DisplayName("[TC-ENTITY-001] softDelete 호출 시 isDeleted가 true로 변경되고 socialId가 DELETED_ 접두사로 변경된다")
-    void softDelete_setsIsDeletedTrueAndChangesSocialId() {
-        // given
-        String originalSocialId = "kakao_12345";
-        User user = User.builder()
-                .socialType(SocialType.KAKAO)
-                .socialId(originalSocialId)
-                .name("test")
-                .email("test@test.com")
-                .isPushAlarm(true)
-                .build();
-
-        // when
-        user.softDelete();
-
-        // then
-        assertThat(user.isDeleted()).isTrue();
-        assertThat(user.getSocialId()).startsWith("DELETED_");
-        assertThat(user.getSocialId()).endsWith("_" + originalSocialId);
-    }
-
-    @Test
-    @DisplayName("[TC-ENTITY-002] isDeleted 기본값은 false이다")
+    @DisplayName("[TC-ENTITY-001] isDeleted 기본값은 false이다")
     void isDeleted_defaultIsFalse() {
         // given
         User user = User.builder()

--- a/src/test/java/server/poptato/user/infra/JpaUserRepositoryTest.java
+++ b/src/test/java/server/poptato/user/infra/JpaUserRepositoryTest.java
@@ -1,0 +1,149 @@
+package server.poptato.user.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import server.poptato.configuration.DatabaseTestConfig;
+import server.poptato.configuration.MySqlDataJpaTest;
+import server.poptato.user.domain.entity.User;
+import server.poptato.user.domain.value.SocialType;
+import server.poptato.user.infra.repository.JpaUserRepository;
+
+@MySqlDataJpaTest
+public class JpaUserRepositoryTest extends DatabaseTestConfig {
+
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
+
+    private User createUser(String socialId, String name, boolean isPushAlarm) {
+        User user = User.builder()
+                .socialType(SocialType.KAKAO)
+                .socialId(socialId)
+                .name(name)
+                .email(name + "@test.com")
+                .isPushAlarm(isPushAlarm)
+                .build();
+        tem.persist(user);
+        tem.flush();
+        tem.clear();
+        return user;
+    }
+
+    private Boolean getIsDeleted(Long id) {
+        return (Boolean) tem.getEntityManager().createNativeQuery(
+                "SELECT is_deleted FROM users WHERE id = :id"
+        ).setParameter("id", id).getSingleResult();
+    }
+
+    private void softDeleteUser(Long userId) {
+        tem.getEntityManager().createNativeQuery(
+                "UPDATE users SET is_deleted = true, social_id = CONCAT('DELETED_', social_id) WHERE id = :id"
+        ).setParameter("id", userId).executeUpdate();
+        tem.flush();
+        tem.clear();
+    }
+
+    @Nested
+    @DisplayName("[SCN-REP-USER-001] @SQLRestriction 동작 테스트")
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    class SQLRestrictionTests {
+
+        @Test
+        @DisplayName("[TC-SQL-RESTRICTION-001] soft delete된 User는 findById로 조회되지 않는다")
+        void findById_excludesSoftDeletedUser() {
+            // given
+            User user = createUser("social123", "testUser", true);
+            Long userId = user.getId();
+
+            softDeleteUser(userId);
+
+            // when
+            Optional<User> found = jpaUserRepository.findById(userId);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("[TC-SQL-RESTRICTION-002] soft delete된 User는 findBySocialId로 조회되지 않는다")
+        void findBySocialId_excludesSoftDeletedUser() {
+            // given
+            String socialId = "social456";
+            User user = createUser(socialId, "testUser", true);
+
+            softDeleteUser(user.getId());
+
+            // when
+            Optional<User> found = jpaUserRepository.findBySocialId(socialId);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+
+        @Test
+        @DisplayName("[TC-SQL-RESTRICTION-003] soft delete된 User는 findAllUserIds에서 제외된다")
+        void findAllUserIds_excludesSoftDeletedUser() {
+            // given
+            User activeUser = createUser("active123", "activeUser", true);
+            User deletedUser = createUser("deleted123", "deletedUser", true);
+
+            softDeleteUser(deletedUser.getId());
+
+            // when
+            List<Long> userIds = jpaUserRepository.findAllUserIds();
+
+            // then
+            assertThat(userIds).contains(activeUser.getId());
+            assertThat(userIds).doesNotContain(deletedUser.getId());
+        }
+
+        @Test
+        @DisplayName("[TC-SQL-RESTRICTION-004] soft delete된 User는 findByIsPushAlarmTrue에서 제외된다")
+        void findByIsPushAlarmTrue_excludesSoftDeletedUser() {
+            // given
+            User activeUser = createUser("push123", "pushUser", true);
+            User deletedUser = createUser("pushDeleted123", "pushDeletedUser", true);
+
+            softDeleteUser(deletedUser.getId());
+
+            // when
+            List<User> users = jpaUserRepository.findByIsPushAlarmTrue();
+
+            // then
+            assertThat(users).extracting(User::getId).contains(activeUser.getId());
+            assertThat(users).extracting(User::getId).doesNotContain(deletedUser.getId());
+        }
+
+        @Test
+        @DisplayName("[TC-SQL-RESTRICTION-005] soft delete된 User는 count에서 제외된다")
+        void count_excludesSoftDeletedUser() {
+            // given
+            long initialCount = jpaUserRepository.count();
+
+            User activeUser = createUser("count123", "countUser", true);
+            User deletedUser = createUser("countDeleted123", "countDeletedUser", true);
+
+            // when - before soft delete
+            long countBeforeDelete = jpaUserRepository.count();
+
+            // then
+            assertThat(countBeforeDelete).isEqualTo(initialCount + 2);
+
+            // when - after soft delete
+            softDeleteUser(deletedUser.getId());
+            long countAfterDelete = jpaUserRepository.count();
+
+            // then
+            assertThat(countAfterDelete).isEqualTo(initialCount + 1);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
  > 어떤 변경 사항이 있었나요?

  - [x] 새로운 기능 추가
  - [ ] 버그 수정
  - [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
  - [x] 코드 리팩토링
  - [ ] 테스트코드 추가
  - [ ] 성능 개선 작업
  - [ ] 주석 추가 및 수정
  - [ ] 문서 수정
  - [ ] 빌드 부분 혹은 패키지 매니저 수정
  - [ ] 파일 혹은 폴더명 수정
  - [ ] 파일 혹은 폴더 삭제

  ---

  ## 🚀 작업 내용
  > 이번 PR에서 작업한 내용을 구체적으로 설명해주세요. (이미지 첨부 가능)

  - User, Todo, Category, Note 엔티티에 `is_deleted` 필드 추가 및 `softDelete()` 메서드 구현
  - 모든 조회 쿼리에 `isDeleted = false` 필터 추가하여 삭제된 데이터 자동 제외
  - 서비스 레이어의 물리 삭제(delete)를 논리 삭제(softDelete)로 변경
  - 사용자 탈퇴 시 연관 데이터(Todo, Category, Note) 일괄 soft delete 처리
  - 카테고리 삭제 시 연관 Todo도 함께 soft delete 처리
  - 테스트 코드 soft delete 방식에 맞게 수정

  ---

  ## 💬 기타 사항 or 추가 코멘트
  > 남기고 싶은 말, 참고 블로그 등이 있다면 기록해주세요.

  ⚠️ **배포 전 마이그레이션 스크립트 실행 필요**
  ```sql
  ALTER TABLE users ADD COLUMN is_deleted BIT NOT NULL DEFAULT 0;
  ALTER TABLE todo ADD COLUMN is_deleted BIT NOT NULL DEFAULT 0;
  ALTER TABLE category ADD COLUMN is_deleted BIT NOT NULL DEFAULT 0;
  ALTER TABLE note ADD COLUMN is_deleted BIT NOT NULL DEFAULT 0;

  -- FK CASCADE 제거
  ALTER TABLE time_alarm DROP FOREIGN KEY fk_timealarm_todo;
  ALTER TABLE time_alarm DROP FOREIGN KEY fk_timealarm_user;

  -- 인덱스 추가
  CREATE INDEX idx_users_is_deleted ON users(is_deleted);
  CREATE INDEX idx_todo_is_deleted ON todo(is_deleted);
  CREATE INDEX idx_todo_user_deleted ON todo(user_id, is_deleted);
  CREATE INDEX idx_category_is_deleted ON category(is_deleted);
  CREATE INDEX idx_category_user_deleted ON category(user_id, is_deleted);
  CREATE INDEX idx_note_is_deleted ON note(is_deleted);
  CREATE INDEX idx_note_user_deleted ON note(user_id, is_deleted);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 삭제 방식이 하드 삭제에서 소프트 삭제로 전환되어 할 일, 노트, 카테고리, 사용자 등의 데이터가 논리적으로 숨겨지고 보존됩니다.
  * 조회·집계·검색 쿼리가 소프트 삭제된 항목을 일관되게 제외하도록 업데이트되었습니다(엔티티 수준 필터 적용 포함).
  * 사용자 삭제 시 연관 데이터는 소프트 삭제, 모바일 정보만 물리 삭제로 유지됩니다.
  * .gitignore에 .worktrees 항목 추가.
  * 예외 로깅에 스택트레이스가 포함되도록 로그 출력이 개선되었습니다.
* **Tests**
  * 소프트 삭제 동작을 검증하는 단위·통합 테스트 대폭 추가 및 기존 테스트 기대 동작 업데이트.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->