### PR TITLE
[ILLDAN-203] fix: 히스토리 조회 시 발생하는 500 에러를 해결한다

### DIFF
--- a/src/main/java/server/poptato/todo/application/TodoService.java
+++ b/src/main/java/server/poptato/todo/application/TodoService.java
@@ -383,10 +383,13 @@ public class TodoService {
             findTodo.incompleteTodayTodo(minTodayOrder);
 
             // 기존 완료 기록이 존재하면 삭제, 없으면 예외 발생
-            CompletedDateTime completedDateTime = completedDateTimeRepository
-                    .findByTodoIdAndDate(findTodo.getId(), findTodo.getTodayDate())
-                    .orElseThrow(() -> new CustomException(TodoErrorStatus._COMPLETED_DATETIME_NOT_EXIST));
-            completedDateTimeRepository.delete(completedDateTime);
+            // 동시 요청 등으로 같은 날짜에 완료 기록이 다건 쌓일 수 있어, 잔여 기록이 히스토리에 남지 않도록 전부 삭제한다
+            List<CompletedDateTime> completedDateTimes = completedDateTimeRepository
+                    .findAllByTodoIdAndDate(findTodo.getId(), findTodo.getTodayDate());
+            if (completedDateTimes.isEmpty()) {
+                throw new CustomException(TodoErrorStatus._COMPLETED_DATETIME_NOT_EXIST);
+            }
+            completedDateTimes.forEach(completedDateTimeRepository::delete);
         }
     }
 

--- a/src/main/java/server/poptato/todo/domain/repository/CompletedDateTimeRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/CompletedDateTimeRepository.java
@@ -6,21 +6,16 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface CompletedDateTimeRepository {
 
-    List<CompletedDateTime> findAllByTodoIdAndDate(Long todoId, LocalDate todayDate);
-
     /**
-     * 특정 할 일의 해당 날짜 완료 기록 중 가장 최근 1건을 조회합니다.
+     * 특정 할 일의 해당 날짜 완료 기록을 모두 조회합니다.
      * <p>
-     * 하루에 여러 번 완료되어 기록이 다건 존재할 수 있으므로 단건 조회로 두면 예외가 발생합니다.
-     * 미완료 토글 시 가장 마지막 완료 기록부터 제거하도록 최신 1건을 반환합니다.
+     * 동시 요청 등으로 같은 날짜에 기록이 다건 쌓일 수 있어 단건이 아닌 목록으로 반환합니다.
+     * todoId만으로 조회하므로 호출 전에 할 일의 소유권 검증이 선행되어야 합니다.
      */
-    default Optional<CompletedDateTime> findByTodoIdAndDate(Long todoId, LocalDate todayDate) {
-        return findAllByTodoIdAndDate(todoId, todayDate).stream().findFirst();
-    }
+    List<CompletedDateTime> findAllByTodoIdAndDate(Long todoId, LocalDate todayDate);
 
     void delete(CompletedDateTime completedDateTime);
 

--- a/src/main/java/server/poptato/todo/domain/repository/CompletedDateTimeRepository.java
+++ b/src/main/java/server/poptato/todo/domain/repository/CompletedDateTimeRepository.java
@@ -10,7 +10,17 @@ import java.util.Optional;
 
 public interface CompletedDateTimeRepository {
 
-    Optional<CompletedDateTime> findByTodoIdAndDate(Long id, LocalDate todayDate);
+    List<CompletedDateTime> findAllByTodoIdAndDate(Long todoId, LocalDate todayDate);
+
+    /**
+     * 특정 할 일의 해당 날짜 완료 기록 중 가장 최근 1건을 조회합니다.
+     * <p>
+     * 하루에 여러 번 완료되어 기록이 다건 존재할 수 있으므로 단건 조회로 두면 예외가 발생합니다.
+     * 미완료 토글 시 가장 마지막 완료 기록부터 제거하도록 최신 1건을 반환합니다.
+     */
+    default Optional<CompletedDateTime> findByTodoIdAndDate(Long todoId, LocalDate todayDate) {
+        return findAllByTodoIdAndDate(todoId, todayDate).stream().findFirst();
+    }
 
     void delete(CompletedDateTime completedDateTime);
 

--- a/src/main/java/server/poptato/todo/infra/repository/JpaCompletedDateTimeRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaCompletedDateTimeRepository.java
@@ -9,17 +9,17 @@ import server.poptato.todo.domain.repository.CompletedDateTimeRepository;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface JpaCompletedDateTimeRepository extends CompletedDateTimeRepository, JpaRepository<CompletedDateTime, Long> {
 
     @Query("""
     SELECT c
-    FROM CompletedDateTime c 
+    FROM CompletedDateTime c
     WHERE c.todoId = :todoId
       AND FUNCTION('DATE', c.dateTime) = :todayDate
+    ORDER BY c.dateTime DESC
     """)
-    Optional<CompletedDateTime> findByTodoIdAndDate(
+    List<CompletedDateTime> findAllByTodoIdAndDate(
             @Param("todoId") Long todoId,
             @Param("todayDate") LocalDate todayDate
     );

--- a/src/main/java/server/poptato/todo/infra/repository/JpaCompletedDateTimeRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaCompletedDateTimeRepository.java
@@ -17,7 +17,6 @@ public interface JpaCompletedDateTimeRepository extends CompletedDateTimeReposit
     FROM CompletedDateTime c
     WHERE c.todoId = :todoId
       AND FUNCTION('DATE', c.dateTime) = :todayDate
-    ORDER BY c.dateTime DESC
     """)
     List<CompletedDateTime> findAllByTodoIdAndDate(
             @Param("todoId") Long todoId,

--- a/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
+++ b/src/main/java/server/poptato/todo/infra/repository/JpaTodoRepository.java
@@ -191,6 +191,13 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
             Pageable pageable
     );
 
+    /**
+     * 특정 날짜에 완료된 할 일을 완료 시각 오름차순으로 조회합니다.
+     * <p>
+     * 같은 할 일이 하루에 여러 번 완료될 수 있어 CompletedDateTime이 다건 존재할 수 있으므로,
+     * ORDER BY 절의 상관 서브쿼리는 반드시 MIN으로 단일 행을 보장해야 합니다.
+     * (스칼라 서브쿼리로 두면 다건일 때 MySQL 1242 "Subquery returns more than 1 row"로 실패)
+     */
     @Query("""
         SELECT t
         FROM Todo t
@@ -201,7 +208,7 @@ public interface JpaTodoRepository extends JpaRepository<Todo, Long> {
         )
           AND t.userId = :userId
         ORDER BY (
-            SELECT c.dateTime
+            SELECT MIN(c.dateTime)
             FROM CompletedDateTime c
             WHERE c.todoId = t.id
               AND DATE(c.dateTime) = :localDate

--- a/src/test/java/server/poptato/todo/application/TodoServiceTest.java
+++ b/src/test/java/server/poptato/todo/application/TodoServiceTest.java
@@ -614,8 +614,8 @@ class TodoServiceTest extends ServiceTestConfig {
             doNothing().when(userValidator).checkIsExistUser(userId);
             when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
             when(todoRepository.findMinTodayOrderByUserIdOrZero(userId)).thenReturn(1);
-            when(completedDateTimeRepository.findByTodoIdAndDate(todoId, todayDate))
-                    .thenReturn(Optional.of(completedDateTime));
+            when(completedDateTimeRepository.findAllByTodoIdAndDate(todoId, todayDate))
+                    .thenReturn(List.of(completedDateTime));
 
             // when
             todoService.updateIsCompleted(userId, todoId);
@@ -623,6 +623,37 @@ class TodoServiceTest extends ServiceTestConfig {
             // then
             verify(todo).incompleteTodayTodo(1);
             verify(completedDateTimeRepository).delete(completedDateTime);
+        }
+
+        @Test
+        @DisplayName("[TC-CMP-003] 완료 -> 미완료 변경 시 같은 날짜의 완료 기록이 다건이면 모두 삭제된다")
+        void updateIsCompleted_duplicatedCompletedDateTime_deletesAll() {
+            // given
+            Long userId = 1L;
+            Long todoId = 100L;
+            LocalDate todayDate = LocalDate.now();
+
+            Todo todo = mock(Todo.class);
+            when(todo.getUserId()).thenReturn(userId);
+            when(todo.getId()).thenReturn(todoId);
+            when(todo.getTodayStatus()).thenReturn(TodayStatus.COMPLETED);
+            when(todo.getTodayDate()).thenReturn(todayDate);
+
+            CompletedDateTime first = mock(CompletedDateTime.class);
+            CompletedDateTime second = mock(CompletedDateTime.class);
+
+            doNothing().when(userValidator).checkIsExistUser(userId);
+            when(todoRepository.findById(todoId)).thenReturn(Optional.of(todo));
+            when(todoRepository.findMinTodayOrderByUserIdOrZero(userId)).thenReturn(1);
+            when(completedDateTimeRepository.findAllByTodoIdAndDate(todoId, todayDate))
+                    .thenReturn(List.of(first, second));
+
+            // when
+            todoService.updateIsCompleted(userId, todoId);
+
+            // then - 잔여 기록이 히스토리에 남지 않도록 전부 삭제됨
+            verify(completedDateTimeRepository).delete(first);
+            verify(completedDateTimeRepository).delete(second);
         }
     }
 

--- a/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
+++ b/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
@@ -243,22 +243,23 @@ public class JpaTodoRepositoryTest extends DatabaseTestConfig {
         @Test
         @DisplayName("[TC-HISTORY-002] 히스토리는 그날의 첫 완료 시각 오름차순으로 정렬된다")
         void findHistories_multipleTodos_sortedByFirstCompletedTime() {
-            // given - 늦게 완료된 할 일이 중복 기록으로 이른 시각도 함께 가지도록 구성
+            // given - 중복 기록을 가진 할 일이 단건 할 일의 완료 시각 앞뒤에 걸치도록 구성
+            //         (첫 완료 기준이면 duplicated가 먼저, 마지막 완료 기준이면 single이 먼저 정렬됨)
             Long userId = 301L;
             LocalDate completedDate = LocalDate.of(2025, 10, 2);
-            Todo early = createTodo(userId, null, "먼저 완료");
-            Todo late = createTodo(userId, null, "나중 완료");
-            createCompletedDateTime(early.getId(), completedDate.atTime(9, 0, 0));
-            createCompletedDateTime(late.getId(), completedDate.atTime(11, 0, 0));
-            createCompletedDateTime(late.getId(), completedDate.atTime(23, 0, 0));
+            Todo duplicated = createTodo(userId, null, "중복 기록 할 일");
+            Todo single = createTodo(userId, null, "단건 기록 할 일");
+            createCompletedDateTime(duplicated.getId(), completedDate.atTime(8, 0, 0));
+            createCompletedDateTime(duplicated.getId(), completedDate.atTime(20, 0, 0));
+            createCompletedDateTime(single.getId(), completedDate.atTime(12, 0, 0));
 
             // when
             var page = jpaTodoRepository.findHistories(userId, completedDate, PageRequest.of(0, 10));
 
-            // then
+            // then - 마지막 완료 시각(20:00)이 아니라 첫 완료 시각(08:00) 기준으로 정렬됨
             assertThat(page.getContent()).hasSize(2);
-            assertThat(page.getContent().get(0).getId()).isEqualTo(early.getId());
-            assertThat(page.getContent().get(1).getId()).isEqualTo(late.getId());
+            assertThat(page.getContent().get(0).getId()).isEqualTo(duplicated.getId());
+            assertThat(page.getContent().get(1).getId()).isEqualTo(single.getId());
         }
     }
 }

--- a/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
+++ b/src/test/java/server/poptato/todo/infra/JpaTodoRepositoryTest.java
@@ -8,9 +8,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import server.poptato.configuration.DatabaseTestConfig;
 import server.poptato.configuration.MySqlDataJpaTest;
+import server.poptato.todo.domain.entity.CompletedDateTime;
 import server.poptato.todo.domain.entity.Todo;
 import server.poptato.todo.domain.value.TodayStatus;
 import server.poptato.todo.domain.value.Type;
@@ -34,6 +39,15 @@ public class JpaTodoRepositoryTest extends DatabaseTestConfig {
         tem.flush();
         tem.clear();
         return todo;
+    }
+
+    private void createCompletedDateTime(Long todoId, LocalDateTime dateTime) {
+        tem.persist(CompletedDateTime.builder()
+                .todoId(todoId)
+                .dateTime(dateTime)
+                .build());
+        tem.flush();
+        tem.clear();
     }
 
     private Boolean getIsDeleted(Long id) {
@@ -199,6 +213,52 @@ public class JpaTodoRepositoryTest extends DatabaseTestConfig {
             // then - active-todo만 조회됨
             assertThat(page.getContent()).hasSize(1);
             assertThat(page.getContent().get(0).getContent()).isEqualTo("active-todo");
+        }
+    }
+
+    @Nested
+    @DisplayName("[SCN-REP-TODO-002] 히스토리 조회 테스트")
+    @TestMethodOrder(MethodOrderer.DisplayName.class)
+    class FindHistoriesTests {
+
+        @Test
+        @DisplayName("[TC-HISTORY-001] 같은 날짜에 완료 기록이 여러 건이어도 히스토리 조회에 성공한다")
+        void findHistories_duplicatedCompletedDateTime_returnsTodoOnce() {
+            // given - 하나의 할 일에 같은 날짜의 완료 기록이 3건 존재
+            Long userId = 300L;
+            LocalDate completedDate = LocalDate.of(2025, 9, 30);
+            Todo todo = createTodo(userId, null, "중복 완료 할 일");
+            createCompletedDateTime(todo.getId(), completedDate.atTime(2, 18, 56));
+            createCompletedDateTime(todo.getId(), completedDate.atTime(10, 0, 0));
+            createCompletedDateTime(todo.getId(), completedDate.atTime(18, 30, 0));
+
+            // when
+            var page = jpaTodoRepository.findHistories(userId, completedDate, PageRequest.of(0, 10));
+
+            // then - 다건이어도 예외 없이 할 일이 한 번만 조회됨
+            assertThat(page.getContent()).hasSize(1);
+            assertThat(page.getContent().get(0).getId()).isEqualTo(todo.getId());
+        }
+
+        @Test
+        @DisplayName("[TC-HISTORY-002] 히스토리는 그날의 첫 완료 시각 오름차순으로 정렬된다")
+        void findHistories_multipleTodos_sortedByFirstCompletedTime() {
+            // given - 늦게 완료된 할 일이 중복 기록으로 이른 시각도 함께 가지도록 구성
+            Long userId = 301L;
+            LocalDate completedDate = LocalDate.of(2025, 10, 2);
+            Todo early = createTodo(userId, null, "먼저 완료");
+            Todo late = createTodo(userId, null, "나중 완료");
+            createCompletedDateTime(early.getId(), completedDate.atTime(9, 0, 0));
+            createCompletedDateTime(late.getId(), completedDate.atTime(11, 0, 0));
+            createCompletedDateTime(late.getId(), completedDate.atTime(23, 0, 0));
+
+            // when
+            var page = jpaTodoRepository.findHistories(userId, completedDate, PageRequest.of(0, 10));
+
+            // then
+            assertThat(page.getContent()).hasSize(2);
+            assertThat(page.getContent().get(0).getId()).isEqualTo(early.getId());
+            assertThat(page.getContent().get(1).getId()).isEqualTo(late.getId());
         }
     }
 }


### PR DESCRIPTION
## 개요

prod에서 `GET /histories`가 500(GLOBAL-500)을 반환하던 문제를 해결합니다.

## 문제

```
SQL Error: 1242, SQLState: 21000
Subquery returns more than 1 row
```

`findHistories`의 `ORDER BY` 상관 서브쿼리가 스칼라(1행)를 가정하는데, 같은 할 일이 하루에 완료 기록(`completed_date_time`)을 2건 이상 가지면 다중 행을 반환해 실패합니다. `WHERE ... IN` 서브쿼리는 다건이 정상이라 걸러지지 않고 정렬 절에서만 터지기 때문에, 특정 유저·특정 날짜에서만 재현됩니다.

- 발생 규모: 48시간 내 7건
- prod DB 실측: 중복 8그룹 / 17행 / 유저 3명 (최대 3중복)

중복이 쌓인 경로는 3가지로 확인했습니다.

| 유형 | 근거 | 성격 |
|---|---|---|
| 하루에 두 번 완료 | 완료 시각이 몇 시간 차 | 정상 |
| `checkYesterdayTodos` 이중 제출 | `23:59:00.000000` 동일값 2건 | 버그 |
| 완료 토글 동시 요청 레이스 | 마이크로초 차 3건 | 버그 |

## 변경 사항

### 1. `findHistories` 정렬 서브쿼리를 `MIN`으로 보정

`ORDER BY (SELECT c.dateTime ...)` → `ORDER BY (SELECT MIN(c.dateTime) ...)`. 완료 기록이 다건이어도 항상 단일 행이 보장되며, 정렬 기준은 "그날의 첫 완료 시각"입니다.

### 2. 미완료 토글 시 그날의 완료 기록을 전부 삭제

`findByTodoIdAndDate`(`Optional` 단건 조회)는 중복 상황에서 예외가 발생할 수 있어 `findAllByTodoIdAndDate`(다건)로 교체했습니다.

최신 1건만 삭제하지 않고 전부 삭제하는 이유는, 잔여 기록이 남으면 실제로는 `INCOMPLETE`인 할 일이 `/histories`에 계속 완료로 노출되기 때문입니다. 기존 코드는 이 상황에서 500으로 실패해 문제가 드러났지만, 단건 조회만 다건으로 바꾸면 조용히 성공하면서 정합성 문제를 숨기게 됩니다.

### 3. 회귀 테스트 추가

- `JpaTodoRepositoryTest` (`SCN-REP-TODO-002`, Testcontainers MySQL 8.0.42)
  - 같은 날짜 완료 기록 3건이 있어도 조회 성공
  - 중복 기록(08:00, 20:00)을 단건 기록(12:00) 앞뒤에 걸치도록 배치해, 정렬 키가 마지막 완료가 아닌 **첫 완료 시각**임을 실제로 구분
- `TodoServiceTest` (`TC-CMP-003`) — 미완료 토글 시 중복 기록 전부 삭제 검증

## 범위 밖 (후속 과제)

- 중복 유입 자체를 막는 동시성/멱등 처리 (완료 토글 분산 락, `checkYesterdayTodos` 멱등화)
- `completed_date_time`에 `(todo_id, date_time)` 인덱스 부재
- `GET /histories`의 `size` 파라미터 상한 부재 (다른 페이징 API도 동일한 기존 패턴)

기존 중복 데이터 17행은 이번 수정으로 무해해지므로 별도 정리하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 오늘 할 일을 미완료로 되돌릴 때, 같은 날짜에 기록된 모든 완료 기록이 정상적으로 삭제됩니다.
  * 완료 기록이 여러 개 있어도 할 일 히스토리가 중복 표시되지 않습니다.
  * 히스토리가 최초 완료 시각을 기준으로 올바르게 정렬됩니다.

* **테스트**
  * 여러 완료 기록 처리와 히스토리 중복·정렬 문제에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->